### PR TITLE
"Restyled" README.md so that it follows Markdown Style Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Erupe Community Edition
+
 This is a community upload of a community project. The amount of people who worked on it is innumerous, and hard to keep track of. Credits to Andoryuuta, Fist's Team, the French Team, Mai's Team and many others. No matter the relations, these files will remain public and open source, free for all to use and modify.
 
-A pastebin with various links, tips, and FAQ: https://pastebin.com/QqAwZSTC
+[A pastebin with various links, tips, and FAQ](https://pastebin.com/QqAwZSTC)
 
-An upload for the quest and scenario files exists here: https://github.com/xl3lackout/MHFZ-Quest-Files
+[An upload for the quest and scenario files exists here](https://github.com/xl3lackout/MHFZ-Quest-Files)
 (Over 300k+ files)


### PR DESCRIPTION
As stated in the [MD034](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md034), no bare URLs must be used, so I changed it (without using angle brackets)