### PR TITLE
Added world_name and land columns to the servers table 

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"erupe-ce/server/entranceserver"
 	"erupe-ce/server/launcherserver"
 	"erupe-ce/server/signserver"
+
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 	"go.uber.org/zap"
@@ -173,6 +174,8 @@ func main() {
 	ci := 0
 	count := 1
 	for _, ee := range erupeConfig.Entrance.Entries {
+		cn := 1
+
 		for _, ce := range ee.Channels {
 			sid := (4096 + si*256) + (16 + ci)
 			c := *channelserver.NewServer(&channelserver.Config{
@@ -192,12 +195,13 @@ func main() {
 			if err != nil {
 				preventClose(fmt.Sprintf("Failed to start channel server: %s", err.Error()))
 			} else {
-				channelQuery += fmt.Sprintf("INSERT INTO servers (server_id, season, current_players) VALUES (%d, %d, 0);", sid, si%3)
+				channelQuery += fmt.Sprintf("INSERT INTO servers (server_id, season, current_players, world_name, land) VALUES (%d, %d, 0, '%s', %d);", sid, si%3, ee.Name, cn)
 				channels = append(channels, &c)
 				logger.Info(fmt.Sprintf("Started channel server %d on port %d", count, ce.Port))
 				ci++
 				count++
 			}
+			cn++
 		}
 		ci = 0
 		si++

--- a/main.go
+++ b/main.go
@@ -174,9 +174,7 @@ func main() {
 	ci := 0
 	count := 1
 	for _, ee := range erupeConfig.Entrance.Entries {
-		cn := 1
-
-		for _, ce := range ee.Channels {
+		for i, ce := range ee.Channels {
 			sid := (4096 + si*256) + (16 + ci)
 			c := *channelserver.NewServer(&channelserver.Config{
 				ID:          uint16(sid),
@@ -195,13 +193,12 @@ func main() {
 			if err != nil {
 				preventClose(fmt.Sprintf("Failed to start channel server: %s", err.Error()))
 			} else {
-				channelQuery += fmt.Sprintf("INSERT INTO servers (server_id, season, current_players, world_name, land) VALUES (%d, %d, 0, '%s', %d);", sid, si%3, ee.Name, cn)
+				channelQuery += fmt.Sprintf(`INSERT INTO servers (server_id, season, current_players, world_name, world_description, land) VALUES (%d, %d, 0, '%s', '%s', %d);`, sid, si%3, ee.Name, ee.Description, i+1)
 				channels = append(channels, &c)
 				logger.Info(fmt.Sprintf("Started channel server %d on port %d", count, ce.Port))
 				ci++
 				count++
 			}
-			cn++
 		}
 		ci = 0
 		si++

--- a/patch-schema/servers_info.sql
+++ b/patch-schema/servers_info.sql
@@ -8,3 +8,10 @@ CREATE TABLE IF NOT EXISTS public.servers
     world_name text COLLATE pg_catalog."default",
     land integer
 )
+
+
+ALTER TABLE IF EXISTS public.servers
+    ADD COLUMN land integer;
+
+ALTER TABLE IF EXISTS public.servers
+    ADD COLUMN world_name text COLLATE pg_catalog."default";

--- a/patch-schema/servers_info.sql
+++ b/patch-schema/servers_info.sql
@@ -7,14 +7,17 @@ CREATE TABLE IF NOT EXISTS public.servers
     season integer NOT NULL,
     current_players integer NOT NULL,
     world_name text COLLATE pg_catalog."default",
+    world_description text,
     land integer
-)
+);
 
+ALTER TABLE public.servers
+    ADD COLUMN IF NOT EXISTS land integer;
 
-ALTER TABLE IF EXISTS public.servers
-    ADD COLUMN land integer;
+ALTER TABLE public.servers
+    ADD COLUMN IF NOT EXISTS world_name text COLLATE pg_catalog."default";
 
-ALTER TABLE IF EXISTS public.servers
-    ADD COLUMN world_name text COLLATE pg_catalog."default";
+ALTER TABLE public.servers
+    ADD COLUMN IF NOT EXISTS world_description text;
 
 END;

--- a/patch-schema/servers_info.sql
+++ b/patch-schema/servers_info.sql
@@ -1,4 +1,5 @@
 --adds world_name and land columns
+BEGIN;
 
 CREATE TABLE IF NOT EXISTS public.servers
 (
@@ -15,3 +16,5 @@ ALTER TABLE IF EXISTS public.servers
 
 ALTER TABLE IF EXISTS public.servers
     ADD COLUMN world_name text COLLATE pg_catalog."default";
+
+END;

--- a/patch-schema/servers_info.sql
+++ b/patch-schema/servers_info.sql
@@ -1,0 +1,10 @@
+--adds world_name and land columns
+
+CREATE TABLE IF NOT EXISTS public.servers
+(
+    server_id integer NOT NULL,
+    season integer NOT NULL,
+    current_players integer NOT NULL,
+    world_name text COLLATE pg_catalog."default",
+    land integer
+)


### PR DESCRIPTION
This is to provide easier identification for external and internal applications utilizing the database.
When writing applications to utilize the database, it helps to not have to hardcode identification based on the server_id's alone.



