### PR TITLE
Guild Pagination

### DIFF
--- a/network/mhfpacket/msg_mhf_enumerate_guild.go
+++ b/network/mhfpacket/msg_mhf_enumerate_guild.go
@@ -32,6 +32,7 @@ type MsgMhfEnumerateGuild struct {
 	AckHandle      uint32
 	Type           EnumerateGuildType
 	Page           uint8
+	Sorting        bool
 	RawDataPayload []byte
 }
 
@@ -45,6 +46,8 @@ func (m *MsgMhfEnumerateGuild) Parse(bf *byteframe.ByteFrame, ctx *clientctx.Cli
 	m.AckHandle = bf.ReadUint32()
 	m.Type = EnumerateGuildType(bf.ReadUint8())
 	m.Page = bf.ReadUint8()
+	m.Sorting = bf.ReadBool()
+	bf.ReadUint8()
 	m.RawDataPayload = bf.DataFromCurrent()
 	bf.Seek(-2, io.SeekEnd)
 	return nil

--- a/server/channelserver/handlers_guild.go
+++ b/server/channelserver/handlers_guild.go
@@ -1103,7 +1103,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 	case mhfpacket.ENUMERATE_GUILD_TYPE_GUILD_NAME:
 		bf.ReadBytes(8)
 		searchTerm := fmt.Sprintf(`%%%s%%`, stringsupport.SJISToUTF8(bf.ReadNullTerminatedBytes()))
-		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE g.name ILIKE $1 OFFSET $2`, guildInfoSelectQuery), searchTerm, pkt.Page*10)
+		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE g.name ILIKE $1 OFFSET $2 LIMIT 11`, guildInfoSelectQuery), searchTerm, pkt.Page*10)
 		if err == nil {
 			for rows.Next() {
 				guild, _ := buildGuildObjectFromDbResult(rows, err, s)
@@ -1113,7 +1113,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 	case mhfpacket.ENUMERATE_GUILD_TYPE_LEADER_NAME:
 		bf.ReadBytes(8)
 		searchTerm := fmt.Sprintf(`%%%s%%`, stringsupport.SJISToUTF8(bf.ReadNullTerminatedBytes()))
-		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE lc.name ILIKE $1 OFFSET $2`, guildInfoSelectQuery), searchTerm, pkt.Page*10)
+		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE lc.name ILIKE $1 OFFSET $2 LIMIT 11`, guildInfoSelectQuery), searchTerm, pkt.Page*10)
 		if err == nil {
 			for rows.Next() {
 				guild, _ := buildGuildObjectFromDbResult(rows, err, s)
@@ -1131,9 +1131,9 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_ORDER_MEMBERS:
 		if pkt.Sorting {
-			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY member_count DESC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
+			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY member_count DESC OFFSET $1 LIMIT 11`, guildInfoSelectQuery), pkt.Page*10)
 		} else {
-			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY member_count ASC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
+			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY member_count ASC OFFSET $1 LIMIT 11`, guildInfoSelectQuery), pkt.Page*10)
 		}
 		if err == nil {
 			for rows.Next() {
@@ -1143,9 +1143,9 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_ORDER_REGISTRATION:
 		if pkt.Sorting {
-			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY id ASC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
+			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY id ASC OFFSET $1 LIMIT 11`, guildInfoSelectQuery), pkt.Page*10)
 		} else {
-			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY id DESC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
+			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY id DESC OFFSET $1 LIMIT 11`, guildInfoSelectQuery), pkt.Page*10)
 		}
 		if err == nil {
 			for rows.Next() {
@@ -1155,9 +1155,9 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_ORDER_RANK:
 		if pkt.Sorting {
-			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY rank_rp DESC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
+			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY rank_rp DESC OFFSET $1 LIMIT 11`, guildInfoSelectQuery), pkt.Page*10)
 		} else {
-			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY rank_rp ASC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
+			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY rank_rp ASC OFFSET $1 LIMIT 11`, guildInfoSelectQuery), pkt.Page*10)
 		}
 		if err == nil {
 			for rows.Next() {
@@ -1168,7 +1168,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 	case mhfpacket.ENUMERATE_GUILD_TYPE_MOTTO:
 		mainMotto := bf.ReadUint16()
 		subMotto := bf.ReadUint16()
-		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE main_motto = $1 AND sub_motto = $2 OFFSET $3`, guildInfoSelectQuery), mainMotto, subMotto, pkt.Page*10)
+		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE main_motto = $1 AND sub_motto = $2 OFFSET $3 LIMIT 11`, guildInfoSelectQuery), mainMotto, subMotto, pkt.Page*10)
 		if err == nil {
 			for rows.Next() {
 				guild, _ := buildGuildObjectFromDbResult(rows, err, s)
@@ -1177,7 +1177,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_RECRUITING:
 		// Assume the player wants the newest guilds with open recruitment
-		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE recruiting=true ORDER BY id DESC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
+		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE recruiting=true ORDER BY id DESC OFFSET $1 LIMIT 11`, guildInfoSelectQuery), pkt.Page*10)
 		if err == nil {
 			for rows.Next() {
 				guild, _ := buildGuildObjectFromDbResult(rows, err, s)
@@ -1252,16 +1252,14 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 	bf = byteframe.NewByteFrame()
 
 	if pkt.Type > 8 {
-		if len(guilds) > 10 {
-			bf.WriteUint16(10)
-		} else {
-			bf.WriteUint16(uint16(len(alliances)))
+		hasNextPage := false
+		if len(alliances) > 10 {
+			hasNextPage = true
+			alliances = alliances[:10]
 		}
-		bf.WriteUint8(0x00) // Unk
-		for i, alliance := range alliances {
-			if i == 10 {
-				break
-			}
+			bf.WriteUint16(uint16(len(alliances)))
+		bf.WriteBool(hasNextPage) // Unk
+		for _, alliance := range alliances {
 			bf.WriteUint32(alliance.ID)
 			bf.WriteUint32(alliance.ParentGuild.LeaderCharID)
 			bf.WriteUint16(alliance.TotalMembers)
@@ -1280,16 +1278,14 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 			bf.WriteBool(true)  // TODO: Enable GuildAlliance applications
 		}
 	} else {
+		hasNextPage := false
 		if len(guilds) > 10 {
-			bf.WriteUint16(10)
-		} else {
-			bf.WriteUint16(uint16(len(guilds)))
+			hasNextPage = true
+			guilds = guilds[:10]
 		}
-		bf.WriteUint8(0x01) // Unk
-		for i, guild := range guilds {
-			if i == 10 {
-				break
-			}
+			bf.WriteUint16(uint16(len(guilds)))
+		bf.WriteBool(hasNextPage)
+		for _, guild := range guilds {
 			bf.WriteUint32(guild.ID)
 			bf.WriteUint32(guild.LeaderCharID)
 			bf.WriteUint16(guild.MemberCount)

--- a/server/channelserver/handlers_guild.go
+++ b/server/channelserver/handlers_guild.go
@@ -1101,7 +1101,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 
 	switch pkt.Type {
 	case mhfpacket.ENUMERATE_GUILD_TYPE_GUILD_NAME:
-		bf.ReadBytes(10)
+		bf.ReadBytes(8)
 		searchTerm := fmt.Sprintf(`%%%s%%`, stringsupport.SJISToUTF8(bf.ReadNullTerminatedBytes()))
 		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE g.name ILIKE $1 OFFSET $2`, guildInfoSelectQuery), searchTerm, pkt.Page*10)
 		if err == nil {
@@ -1111,7 +1111,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 			}
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_LEADER_NAME:
-		bf.ReadBytes(10)
+		bf.ReadBytes(8)
 		searchTerm := fmt.Sprintf(`%%%s%%`, stringsupport.SJISToUTF8(bf.ReadNullTerminatedBytes()))
 		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE lc.name ILIKE $1 OFFSET $2`, guildInfoSelectQuery), searchTerm, pkt.Page*10)
 		if err == nil {
@@ -1121,7 +1121,6 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 			}
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_LEADER_ID:
-		bf.ReadBytes(2)
 		ID := bf.ReadUint32()
 		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE leader_id = $1`, guildInfoSelectQuery), ID)
 		if err == nil {
@@ -1131,8 +1130,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 			}
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_ORDER_MEMBERS:
-		sorting := bf.ReadUint8()
-		if sorting == 1 {
+		if pkt.Sorting {
 			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY member_count DESC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
 		} else {
 			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY member_count ASC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
@@ -1144,8 +1142,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 			}
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_ORDER_REGISTRATION:
-		sorting := bf.ReadUint8()
-		if sorting == 1 {
+		if pkt.Sorting {
 			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY id ASC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
 		} else {
 			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY id DESC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
@@ -1157,8 +1154,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 			}
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_ORDER_RANK:
-		sorting := bf.ReadUint8()
-		if sorting == 1 {
+		if pkt.Sorting {
 			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY rank_rp DESC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
 		} else {
 			rows, err = s.server.db.Queryx(fmt.Sprintf(`%s ORDER BY rank_rp ASC OFFSET $1`, guildInfoSelectQuery), pkt.Page*10)
@@ -1170,7 +1166,6 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 			}
 		}
 	case mhfpacket.ENUMERATE_GUILD_TYPE_MOTTO:
-		bf.ReadBytes(2)
 		mainMotto := bf.ReadUint16()
 		subMotto := bf.ReadUint16()
 		rows, err = s.server.db.Queryx(fmt.Sprintf(`%s WHERE main_motto = $1 AND sub_motto = $2 OFFSET $3`, guildInfoSelectQuery), mainMotto, subMotto, pkt.Page*10)
@@ -1202,7 +1197,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 		}
 		switch pkt.Type {
 		case mhfpacket.ENUMERATE_ALLIANCE_TYPE_ALLIANCE_NAME:
-			bf.ReadBytes(10)
+			bf.ReadBytes(8)
 			searchTerm := stringsupport.SJISToUTF8(bf.ReadNullTerminatedBytes())
 			for _, alliance := range tempAlliances {
 				if strings.Contains(alliance.Name, searchTerm) {
@@ -1210,7 +1205,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 				}
 			}
 		case mhfpacket.ENUMERATE_ALLIANCE_TYPE_LEADER_NAME:
-			bf.ReadBytes(10)
+			bf.ReadBytes(8)
 			searchTerm := stringsupport.SJISToUTF8(bf.ReadNullTerminatedBytes())
 			for _, alliance := range tempAlliances {
 				if strings.Contains(alliance.ParentGuild.LeaderName, searchTerm) {
@@ -1218,7 +1213,6 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 				}
 			}
 		case mhfpacket.ENUMERATE_ALLIANCE_TYPE_LEADER_ID:
-			bf.ReadBytes(2)
 			ID := bf.ReadUint32()
 			for _, alliance := range tempAlliances {
 				if alliance.ParentGuild.LeaderCharID == ID {
@@ -1226,8 +1220,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 				}
 			}
 		case mhfpacket.ENUMERATE_ALLIANCE_TYPE_ORDER_MEMBERS:
-			sorting := bf.ReadBool()
-			if sorting {
+			if pkt.Sorting {
 				sort.Slice(tempAlliances, func(i, j int) bool {
 					return tempAlliances[i].TotalMembers > tempAlliances[j].TotalMembers
 				})
@@ -1238,8 +1231,7 @@ func handleMsgMhfEnumerateGuild(s *Session, p mhfpacket.MHFPacket) {
 			}
 			alliances = tempAlliances
 		case mhfpacket.ENUMERATE_ALLIANCE_TYPE_ORDER_REGISTRATION:
-			sorting := bf.ReadBool()
-			if sorting {
+			if pkt.Sorting {
 				sort.Slice(tempAlliances, func(i, j int) bool {
 					return tempAlliances[i].CreatedAt.Unix() > tempAlliances[j].CreatedAt.Unix()
 				})


### PR DESCRIPTION
I found some old changes I made when the repo was still under Andrew's github, decided to port them to the new repo.

Most of the stuff I changed at the time is already implemented, but I noticed pagination was not. There's a byte that was marked as 'Unk' that sets wether the button to go to the next page is clickable or not.

For the implementation, the idea is that you need to know if there's an item after the current page, but without querying the entire table. To do this, you query 1 extra item: if it is there it means there's an extra page. After that we can trim the results so the client still gets only 10 items.

I'm applying the same logic to alliances... but I'll be honest, I don't even know what that is lol. From the structure it looks like it should be the same though.