### PR TITLE
Improving Windows <> Linux portability

### DIFF
--- a/server/channelserver/handlers_data.go
+++ b/server/channelserver/handlers_data.go
@@ -236,7 +236,7 @@ func dumpSaveData(s *Session, data []byte, suffix string) {
 		_, err := os.Stat(dir)
 		if err != nil {
 			if os.IsNotExist(err) {
-				err = os.Mkdir(dir, os.ModeDir)
+				err = os.Mkdir(dir, os.ModePerm)
 				if err != nil {
 					s.logger.Warn("Error dumping savedata, could not create folder")
 					return

--- a/server/channelserver/handlers_quest.go
+++ b/server/channelserver/handlers_quest.go
@@ -27,17 +27,17 @@ func handleMsgSysGetFile(s *Session, p mhfpacket.MHFPacket) {
 		}
 		filename := fmt.Sprintf("%d_0_0_0_S%d_T%d_C%d", pkt.ScenarioIdentifer.CategoryID, pkt.ScenarioIdentifer.MainID, pkt.ScenarioIdentifer.Flags, pkt.ScenarioIdentifer.ChapterID)
 		// Read the scenario file.
-		data, err := os.ReadFile(filepath.Join(s.server.erupeConfig.BinPath, fmt.Sprintf("scenarios/%s.bin", filename)))
+		data, err := os.ReadFile(fmt.Sprintf("scenarios/%s.bin", filename))
 		if err != nil {
-			s.logger.Error(fmt.Sprintf("Failed to open file: %s/scenarios/%s.bin", s.server.erupeConfig.BinPath, filename))
+			s.logger.Error(fmt.Sprintf("Failed to open file: scenarios/%s.bin", filename))
 			// This will crash the game.
 			doAckBufSucceed(s, pkt.AckHandle, data)
 			return
 		}
 		doAckBufSucceed(s, pkt.AckHandle, data)
 	} else {
-		if _, err := os.Stat(filepath.Join(s.server.erupeConfig.BinPath, "quest_override.bin")); err == nil {
-			data, err := os.ReadFile(filepath.Join(s.server.erupeConfig.BinPath, "quest_override.bin"))
+		if _, err := os.Stat("quest_override.bin"); err == nil {
+			data, err := os.ReadFile("quest_override.bin")
 			if err != nil {
 				panic(err)
 			}
@@ -50,9 +50,9 @@ func handleMsgSysGetFile(s *Session, p mhfpacket.MHFPacket) {
 				)
 			}
 			// Get quest file.
-			data, err := os.ReadFile(filepath.Join(s.server.erupeConfig.BinPath, fmt.Sprintf("quests/%s.bin", pkt.Filename)))
+			data, err := os.ReadFile(fmt.Sprintf("quests/%s.bin", pkt.Filename))
 			if err != nil {
-				s.logger.Error(fmt.Sprintf("Failed to open file: %s/quests/%s.bin", s.server.erupeConfig.BinPath, pkt.Filename))
+				s.logger.Error(fmt.Sprintf("Failed to open file: quests/%s.bin", pkt.Filename))
 				// This will crash the game.
 				doAckBufSucceed(s, pkt.AckHandle, data)
 				return


### PR DESCRIPTION
Under Windows: no change
Under Linux: Fix directory creation with no read/write permissions that failed the creation of save data dump

Hello,
While trying to setup Erupe on a linux server I noticed that the directory created by the application did not have any permission set and then failed to create any subdirectory or files once the savegame directory was created, changing this call fix the problem, I did not see any other call to Mkdir in the sources that could call for the same issue.