### PR TITLE
Update handlers_mercenary.go

### DIFF
--- a/server/channelserver/handlers_mercenary.go
+++ b/server/channelserver/handlers_mercenary.go
@@ -1,6 +1,7 @@
 package channelserver
 
 import (
+//	"encoding/hex"
 	"erupe-ce/common/byteframe"
 	"erupe-ce/common/stringsupport"
 	_config "erupe-ce/config"
@@ -9,8 +10,12 @@ import (
 	"erupe-ce/server/channelserver/compression/nullcomp"
 	"go.uber.org/zap"
 	"io"
+	"os"
+	"path/filepath"
 	"time"
 )
+
+
 
 func handleMsgMhfLoadPartner(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgMhfLoadPartner)
@@ -147,11 +152,20 @@ func handleMsgMhfCreateMercenary(s *Session, p mhfpacket.MHFPacket) {
 func handleMsgMhfSaveMercenary(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgMhfSaveMercenary)
 	dumpSaveData(s, pkt.MercData, "mercenary")
-	if len(pkt.MercData) > 0 {
-		temp := byteframe.NewByteFrameFromBytes(pkt.MercData)
+	temp := byteframe.NewByteFrameFromBytes(pkt.MercData)
+	if len(pkt.MercData) > 0 {		
 		s.server.db.Exec("UPDATE characters SET savemercenary=$1, rasta_id=$2 WHERE id=$3", pkt.MercData, temp.ReadUint32(), s.charID)
 	}
-	s.server.db.Exec("UPDATE characters SET gcp=$1, pact_id=$2 WHERE id=$3", pkt.GCP, pkt.PactMercID, s.charID)
+	var rastaGCP, pactID uint32
+	s.server.db.QueryRow("SELECT gcp, pact_id FROM characters WHERE id = $1", s.charID).Scan(&rastaGCP, &pactID)//remove the update pact_id, as the game always null my contract for unknown reason
+	//this logic need to be reworked as if player acquire gcp from tore exchange still be read, maybe need quest tracking?
+	if pkt.GCP >= rastaGCP:
+		rastaGCP = pkt.GCP - rastaGCP
+	else:
+		rastaGCP = 0
+	s.server.db.Exec("UPDATE characters SET gcp=$1 WHERE id=$2", pkt.GCP, s.charID)
+	s.server.db.Exec("UPDATE characters SET gcp=gcp+$1 WHERE id=(SELECT id from characters where rasta_id = $2)", rastaGCP, pactID)
+
 	doAckSimpleSucceed(s, pkt.AckHandle, []byte{0x00, 0x00, 0x00, 0x00})
 }
 
@@ -169,7 +183,7 @@ func handleMsgMhfReadMercenaryW(s *Session, p mhfpacket.MHFPacket) {
 			bf.WriteUint8(1) // numLends
 			bf.WriteUint32(pactID)
 			bf.WriteUint32(cid)
-			bf.WriteBool(false) // ?
+			bf.WriteBool(true) // i change to true as this will trigger read mercenary when taking a quest
 			bf.WriteUint32(uint32(TimeAdjusted().Add(time.Hour * 24 * -8).Unix()))
 			bf.WriteUint32(uint32(TimeAdjusted().Add(time.Hour * 24 * -1).Unix()))
 			bf.WriteBytes(stringsupport.PaddedString(name, 18, true))
@@ -221,8 +235,11 @@ func handleMsgMhfReadMercenaryM(s *Session, p mhfpacket.MHFPacket) {
 	if len(data) == 0 {
 		resp.WriteBool(false)
 	} else {
+		// change the savemercenary data offset 8 into true, as the default is false(00) and make rasta settings disabled when cheking
+		data[8] = 1
 		resp.WriteBytes(data)
 	}
+	resp.WriteUint8(0)
 	doAckBufSucceed(s, pkt.AckHandle, resp.Data())
 }
 
@@ -297,12 +314,18 @@ func handleMsgMhfSaveOtomoAirou(s *Session, p mhfpacket.MHFPacket) {
 func handleMsgMhfEnumerateAiroulist(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgMhfEnumerateAiroulist)
 	resp := byteframe.NewByteFrame()
+	if _, err := os.Stat(filepath.Join(s.server.erupeConfig.BinPath, "airoulist.bin")); err == nil {
+		data, _ := os.ReadFile(filepath.Join(s.server.erupeConfig.BinPath, "airoulist.bin"))
+		resp.WriteBytes(data)
+		doAckBufSucceed(s, pkt.AckHandle, resp.Data())
+		return
+	}
 	airouList := getGuildAirouList(s)
 	resp.WriteUint16(uint16(len(airouList)))
 	resp.WriteUint16(uint16(len(airouList)))
 	for _, cat := range airouList {
-		resp.WriteUint32(cat.ID)
-		resp.WriteBytes(cat.Name)
+		resp.WriteUint32(cat.CatID)
+		resp.WriteBytes(cat.CatName)
 		resp.WriteUint32(cat.Experience)
 		resp.WriteUint8(cat.Personality)
 		resp.WriteUint8(cat.Class)
@@ -313,10 +336,11 @@ func handleMsgMhfEnumerateAiroulist(s *Session, p mhfpacket.MHFPacket) {
 	doAckBufSucceed(s, pkt.AckHandle, resp.Data())
 }
 
-type Airou struct {
-	ID          uint32
-	Name        []byte
-	Task        uint8
+// CatDefinition holds values needed to populate the guild cat list
+type CatDefinition struct {
+	CatID       uint32
+	CatName     []byte
+	CurrentTask uint8
 	Personality uint8
 	Class       uint8
 	Experience  uint32
@@ -324,39 +348,46 @@ type Airou struct {
 	WeaponID    uint16
 }
 
-func getGuildAirouList(s *Session) []Airou {
-	var guildCats []Airou
-	bannedCats := make(map[uint32]int)
-	guild, err := GetGuildInfoByCharacterId(s, s.charID)
+func getGuildAirouList(s *Session) []CatDefinition {
+	var guild *Guild
+	var err error
+	var guildCats []CatDefinition
+
+	// returning 0 cats on any guild issues
+	// can probably optimise all of the guild queries pretty heavily
+	guild, err = GetGuildInfoByCharacterId(s, s.charID)
 	if err != nil {
 		return guildCats
 	}
-	rows, err := s.server.db.Query(`SELECT cats_used FROM guild_hunts gh
-		INNER JOIN characters c ON gh.host_id = c.id WHERE c.id=$1
-	`, s.charID)
+
+	// Get cats used recently
+	// Retail reset at midday, 12 hours is a midpoint
+	tempBanDuration := 43200 - (1800) // Minus hunt time
+	bannedCats := make(map[uint32]int)
+	var csvTemp string
+	rows, err := s.server.db.Query(`SELECT cats_used
+	FROM guild_hunts gh
+	INNER JOIN characters c
+	ON gh.host_id = c.id
+	WHERE c.id=$1 AND gh.return+$2>$3`, s.charID, tempBanDuration, TimeAdjusted().Unix())
 	if err != nil {
 		s.logger.Warn("Failed to get recently used airous", zap.Error(err))
-		return guildCats
 	}
-
-	var csvTemp string
-	var startTemp time.Time
 	for rows.Next() {
-		err = rows.Scan(&csvTemp, &startTemp)
-		if err != nil {
-			continue
-		}
-		if startTemp.Add(time.Second * time.Duration(s.server.erupeConfig.GameplayOptions.TreasureHuntPartnyaCooldown)).Before(TimeAdjusted()) {
-			for i, j := range stringsupport.CSVElems(csvTemp) {
-				bannedCats[uint32(j)] = i
-			}
+		rows.Scan(&csvTemp)
+		for i, j := range stringsupport.CSVElems(csvTemp) {
+			bannedCats[uint32(j)] = i
 		}
 	}
 
-	rows, err = s.server.db.Query(`SELECT c.otomoairou FROM characters c
-	INNER JOIN guild_characters gc ON gc.character_id = c.id
+	// ellie's GetGuildMembers didn't seem to pull leader?
+	rows, err = s.server.db.Query(`SELECT c.otomoairou
+	FROM characters c
+	INNER JOIN guild_characters gc
+	ON gc.character_id = c.id
 	WHERE gc.guild_id = $1 AND c.otomoairou IS NOT NULL
-	ORDER BY c.id LIMIT 60`, guild.ID)
+	ORDER BY c.id ASC
+	LIMIT 60;`, guild.ID)
 	if err != nil {
 		s.logger.Warn("Selecting otomoairou based on guild failed", zap.Error(err))
 		return guildCats
@@ -365,7 +396,11 @@ func getGuildAirouList(s *Session) []Airou {
 	for rows.Next() {
 		var data []byte
 		err = rows.Scan(&data)
-		if err != nil || len(data) == 0 {
+		if err != nil {
+			s.logger.Warn("select failure", zap.Error(err))
+			continue
+		} else if len(data) == 0 {
+			// non extant cats that aren't null in DB
 			continue
 		}
 		// first byte has cat existence in general, can skip if 0
@@ -376,10 +411,10 @@ func getGuildAirouList(s *Session) []Airou {
 				continue
 			}
 			bf := byteframe.NewByteFrameFromBytes(decomp)
-			cats := GetAirouDetails(bf)
+			cats := GetCatDetails(bf)
 			for _, cat := range cats {
-				_, exists := bannedCats[cat.ID]
-				if cat.Task == 4 && !exists {
+				_, exists := bannedCats[cat.CatID]
+				if cat.CurrentTask == 4 && !exists {
 					guildCats = append(guildCats, cat)
 				}
 			}
@@ -388,20 +423,20 @@ func getGuildAirouList(s *Session) []Airou {
 	return guildCats
 }
 
-func GetAirouDetails(bf *byteframe.ByteFrame) []Airou {
+func GetCatDetails(bf *byteframe.ByteFrame) []CatDefinition {
 	catCount := bf.ReadUint8()
-	cats := make([]Airou, catCount)
+	cats := make([]CatDefinition, catCount)
 	for x := 0; x < int(catCount); x++ {
-		var catDef Airou
+		var catDef CatDefinition
 		// cat sometimes has additional bytes for whatever reason, gift items? timestamp?
 		// until actual variance is known we can just seek to end based on start
 		catDefLen := bf.ReadUint32()
 		catStart, _ := bf.Seek(0, io.SeekCurrent)
 
-		catDef.ID = bf.ReadUint32()
-		bf.Seek(1, io.SeekCurrent)     // unknown value, probably a bool
-		catDef.Name = bf.ReadBytes(18) // always 18 len, reads first null terminated string out of section and discards rest
-		catDef.Task = bf.ReadUint8()
+		catDef.CatID = bf.ReadUint32()
+		bf.Seek(1, io.SeekCurrent)        // unknown value, probably a bool
+		catDef.CatName = bf.ReadBytes(18) // always 18 len, reads first null terminated string out of section and discards rest
+		catDef.CurrentTask = bf.ReadUint8()
 		bf.Seek(16, io.SeekCurrent) // appearance data and what is seemingly null bytes
 		catDef.Personality = bf.ReadUint8()
 		catDef.Class = bf.ReadUint8()


### PR DESCRIPTION
rasta update (hacky fix)
mainly developed for forward ver. but works on zz

sidenote, client address (forward.5 ver) :
mhfo.dll+5370DDC : client rasta settings
-default 0000 or no rasta
-0001 means rasta disabled on client side
-0100 means rasta disabled from savemercenary data/other player rasta -0101 means rasta will always follow

mhfo.dll+5370DD4 : another player rasta data will load into this address(wont trigger unless checked first at rasta counter npc)