### PR TITLE
fix config mismatch

### DIFF
--- a/config.json
+++ b/config.json
@@ -84,10 +84,10 @@
   "Discord": {
     "Enabled": false,
     "BotToken": "",
-    "RealTimeChannel": {
+    "RelayChannel": {
       "Enabled": false,
       "MaxMessageLength": 183,
-      "RealTimeChannelID": ""
+      "RelayChannelID": ""
     }
   },
   "Commands": [


### PR DESCRIPTION
The element in config.go doesn't match the one in config.json (RelayChannel vs RealTimeChannel  and RelayChannelID vs RealTimeChannelID). Fixed the JSON so it would match the Config.go . 