### PR TITLE
fix discord bot unknown character vulnerability crashing the server.

### DIFF
--- a/server/discordbot/discord_bot.go
+++ b/server/discordbot/discord_bot.go
@@ -86,6 +86,8 @@ func (bot *DiscordBot) Start() (err error) {
 func (bot *DiscordBot) NormalizeDiscordMessage(message string) string {
 	userRegex := regexp.MustCompile(`<@!?(\d{17,19})>`)
 	emojiRegex := regexp.MustCompile(`(?:<a?)?:(\w+):(?:\d{18}>)?`)
+	messageRegex := regexp.MustCompile(`[^\p{Hiragana}\p{Katakana}\p{Han}\p{P}\p{S}\x{00}-\x{7E}]`)
+	message = messageRegex.ReplaceAllString(message, "")
 
 	result := ReplaceTextAll(message, userRegex, func(userId string) string {
 		user, err := bot.Session.User(userId)


### PR DESCRIPTION
There is an issue where if a message containing unsupported characters (e.g. ( ͡° ͜ʖ ͡°), 𒀜) gets sent in the set discord relay channel, the entire server crashes with an error stating that the rune sent is not supported. This commit adds a regex rule that aims to filter out any characters not belonging to Hiragana, Katakana, Kanji, Alphanumeric and Japanese special characters such as 「」.