### PR TITLE
Allow NULL values in 'data' column of distributions table

### DIFF
--- a/schemas/patch-schema/27-rework-distributions-3.sql
+++ b/schemas/patch-schema/27-rework-distributions-3.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE distribution ALTER COLUMN data DROP NOT NULL;
+
+END;


### PR DESCRIPTION
The data column in the Distribution struct isn’t being used, so it could potentially be removed. For now, I just patched it to allow null values.

For the same reason, DistributionDemo.sql wasn’t working.