### PR TITLE
Add build and upload steps for Android-arm64

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,3 +53,18 @@ jobs:
           ./savedata/
           ./bin/
           ./bundled-schema/
+
+    - name: Build Android-arm64
+      run: env GOOS=linux GOARCH=arm64 go build -v
+        
+    - name: Upload Android-arm64 artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: Android-arm64
+        path: |
+          ./erupe-ce
+          ./config.json
+          ./www/
+          ./savedata/
+          ./bin/
+          ./bundled-schema/


### PR DESCRIPTION
Add a build for arm64 architecture in case someone also need to run the server in her phone to play with friends.