### PR TITLE
fix: soft-delete guild posts instead of hard-deleting

### DIFF
--- a/schemas/patch-schema/28-guild-posts-soft-delete.sql
+++ b/schemas/patch-schema/28-guild-posts-soft-delete.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+-- Add soft-delete column to guild_posts, matching the pattern used by characters and mail tables.
+ALTER TABLE guild_posts ADD COLUMN IF NOT EXISTS deleted boolean DEFAULT false NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
Use a `deleted` boolean column (matching characters and mail tables) instead of permanently removing guild_posts rows. This makes excess post purging and manual deletion reversible.

It includes a migration script (patch-schema/28).

