### PR TITLE
fix(channelserver): correct bookshelf save data pointers for non-ZZ

### DIFF
--- a/server/channelserver/handlers_character.go
+++ b/server/channelserver/handlers_character.go
@@ -85,7 +85,7 @@ func getPointers() map[SavePointer]int {
 		pointers[pHR] = 94550
 		pointers[pGRP] = 94556
 		pointers[pHouseData] = 94561
-		pointers[pBookshelfData] = 89118 // TODO: fix bookshelf data pointer
+		pointers[pBookshelfData] = 103928
 		pointers[pGalleryData] = 104064
 		pointers[pGardenData] = 106424
 		pointers[pRP] = 106614
@@ -98,7 +98,7 @@ func getPointers() map[SavePointer]int {
 		pointers[pToreData] = 62228
 		pointers[pHR] = 62550
 		pointers[pHouseData] = 62561
-		pointers[pBookshelfData] = 57118 // TODO: fix bookshelf data pointer
+		pointers[pBookshelfData] = 71928
 		pointers[pGalleryData] = 72064
 		pointers[pGardenData] = 74424
 		pointers[pRP] = 74614
@@ -110,7 +110,7 @@ func getPointers() map[SavePointer]int {
 		pointers[pToreData] = 14228
 		pointers[pHR] = 14550
 		pointers[pHouseData] = 14561
-		pointers[pBookshelfData] = 9118 // TODO: fix bookshelf data pointer
+		pointers[pBookshelfData] = 23928
 		pointers[pGalleryData] = 24064
 		pointers[pGardenData] = 26424
 		pointers[pRP] = 26614


### PR DESCRIPTION
The pBookshelfData offsets for G1-Z2, F4-F5, and S6 were wrong, causing bookshelf data to overlap with house tier, tore, and house data regions in the save blob. This meant `user_binary.bookshelf` contained garbage data for all non-ZZ versions.

Corrected offsets:

- G1-Z2: 89118 -> 103928 (was off by -14810)
- F4-F5: 57118 -> 71928 (was off by -14810)
- S6:     9118 -> 23928 (was off by -14810)

Related to #92 (but likely not causing it)