### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module erupe-ce
 
-go 1.25
+go 1.25.1
 
 require (
 	github.com/bwmarrin/discordgo v0.27.1


### PR DESCRIPTION
added minor version otherwise go would throw an error similar to go: download go1.25 for linux/amd64: toolchain not available