### PR TITLE
Some mercenary feature implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ tmp/
 # Claude Code local config
 .claude/
 CLAUDE.local.md
+/log

--- a/network/mhfpacket/msg_mhf_save_mercenary.go
+++ b/network/mhfpacket/msg_mhf_save_mercenary.go
@@ -10,10 +10,13 @@ import (
 
 // MsgMhfSaveMercenary represents the MSG_MHF_SAVE_MERCENARY
 type MsgMhfSaveMercenary struct {
-	AckHandle  uint32
-	GCP        uint32
-	PactMercID uint32
-	MercData   []byte
+	AckHandle   uint32
+	GCP         uint32
+	PactMercID  uint32
+	RastaMercID uint32
+	charID      uint32
+	lastState   bool
+	MercData    []byte
 }
 
 // Opcode returns the ID associated with this packet type.
@@ -29,7 +32,13 @@ func (m *MsgMhfSaveMercenary) Parse(bf *byteframe.ByteFrame, ctx *clientctx.Clie
 	m.PactMercID = bf.ReadUint32()
 	dataSize := bf.ReadUint32()
 	_ = bf.ReadUint32() // Merc index?
-	m.MercData = bf.ReadBytes(uint(dataSize))
+	raw := bf.ReadBytes(uint(dataSize))
+	temp := byteframe.NewByteFrameFromBytes(raw)
+	m.RastaMercID = temp.ReadUint32()
+	m.charID = temp.ReadUint32()
+	m.lastState = temp.ReadBool()
+
+	m.MercData = raw[9:]
 	return nil
 }
 

--- a/server/channelserver/handlers_mercenary.go
+++ b/server/channelserver/handlers_mercenary.go
@@ -1,17 +1,18 @@
 package channelserver
 
 import (
+	"database/sql"
+	"errors"
 	"erupe-ce/common/byteframe"
 	"erupe-ce/common/stringsupport"
 	cfg "erupe-ce/config"
 	"erupe-ce/network/mhfpacket"
 	"erupe-ce/server/channelserver/compression/deltacomp"
 	"erupe-ce/server/channelserver/compression/nullcomp"
-	"go.uber.org/zap"
 	"io"
 	"time"
-	"database/sql" // ADD THIS
-	"errors"       // ADD THIS
+
+	"go.uber.org/zap"
 )
 
 func handleMsgMhfLoadPartner(s *Session, p mhfpacket.MHFPacket) {
@@ -270,7 +271,6 @@ func handleMsgMhfSaveMercenary(s *Session, p mhfpacket.MHFPacket) {
 		doAckSimpleSucceed(s, pkt.AckHandle, make([]byte, 4))
 		return
 	}
-
 	dumpSaveData(s, pkt.MercData, "mercenary")
 
 	if len(pkt.MercData) == 0x8B {
@@ -283,6 +283,30 @@ func handleMsgMhfSaveMercenary(s *Session, p mhfpacket.MHFPacket) {
 		}
 	} else {
 		s.logger.Warn("Mercenary payload too small", zap.Int("len", len(pkt.MercData)))
+	}
+
+	var gcp int
+	gcp, gcpErr := readCharacterInt(s, "gcp")
+	if gcpErr != nil {
+		s.logger.Warn("Failed to read gcp", zap.Error(gcpErr))
+	} else if pkt.GCP > uint32(gcp) {
+		difference := pkt.GCP - uint32(gcp)
+		// s.logger.Info("GCP increased",
+		// 	zap.Uint32("old_gcp", uint32(gcp)),
+		// 	zap.Uint32("new_gcp", pkt.GCP),
+		// 	zap.Uint32("difference", difference),
+		// )
+
+		if pkt.PactMercID > 0 {
+			ownerCharID, _, _, ownerErr := s.server.charRepo.FindByRastaID(int(pkt.PactMercID), s.charID)
+			if ownerErr != nil {
+				s.logger.Warn("Failed to find pact owner for GCP credit",
+					zap.Error(ownerErr), zap.Uint32("pactMercID", pkt.PactMercID))
+			} else if _, err := s.server.charRepo.AdjustInt(ownerCharID, "gcp", int(difference)); err != nil {
+				s.logger.Warn("Failed to credit GCP to pact owner",
+					zap.Error(err), zap.Uint32("ownerCharID", ownerCharID))
+			}
+		}
 	}
 
 	if err := s.server.charRepo.UpdateGCPAndPact(s.charID, pkt.GCP, pkt.PactMercID); err != nil {
@@ -379,7 +403,7 @@ func handleMsgMhfReadMercenaryW(s *Session, p mhfpacket.MHFPacket) {
 	doAckBufSucceed(s, pkt.AckHandle, bf.Data())
 }
 
-//This function load contracted mercenary data (triggered by mercenaryW if theres some contract)
+// This function load contracted mercenary data (triggered by mercenaryW if theres some contract)
 func handleMsgMhfReadMercenaryM(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgMhfReadMercenaryM)
 	data, err := s.server.charRepo.LoadColumn(pkt.CharID, "savemercenary")

--- a/server/channelserver/handlers_mercenary.go
+++ b/server/channelserver/handlers_mercenary.go
@@ -10,6 +10,8 @@ import (
 	"go.uber.org/zap"
 	"io"
 	"time"
+	"database/sql" // ADD THIS
+	"errors"       // ADD THIS
 )
 
 func handleMsgMhfLoadPartner(s *Session, p mhfpacket.MHFPacket) {
@@ -141,28 +143,104 @@ func handleMsgMhfSaveHunterNavi(s *Session, p mhfpacket.MHFPacket) {
 
 func handleMsgMhfMercenaryHuntdata(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgMhfMercenaryHuntdata)
-	if pkt.RequestType == 1 {
-		// Format:
-		// uint8 Hunts
-		// struct Hunt
-		//   uint32 HuntID
-		//   uint32 MonID
-		doAckBufSucceed(s, pkt.AckHandle, make([]byte, 1))
-	} else {
+
+	if pkt.RequestType != 1 {
 		doAckBufSucceed(s, pkt.AckHandle, make([]byte, 0))
+		return
 	}
+
+	rastaID, err := s.server.charRepo.ReadInt(s.charID, "rasta_id")
+	if err != nil {
+		s.logger.Error("failed to fetch rasta_id for character", zap.Error(err), zap.Uint32("charID", s.charID))
+		doAckBufSucceed(s, pkt.AckHandle, make([]byte, 1))
+		return
+	}
+
+	defaultClaim := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	lastKillLog, lastClaim, err := s.server.mercenaryRepo.GetLastMercenaryReward(uint32(rastaID), defaultClaim)
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			s.logger.Error("failed to fetch last mercenary claim", zap.Error(err), zap.Uint32("rastaID", uint32(rastaID)))
+			doAckBufSucceed(s, pkt.AckHandle, make([]byte, 1))
+			return
+		}
+		// No previous claim; treat as first claim.
+		lastKillLog = 0
+		lastClaim = defaultClaim
+	}
+
+	// Same boundary logic as the daily reset: current period's noon cutoff,
+	// rolled forward a day if we're already past today's noon.
+	midday := TimeMidnight().Add(12 * time.Hour)
+	if TimeAdjusted().After(midday) {
+		midday = midday.Add(24 * time.Hour)
+	}
+
+	if !midday.After(lastClaim) {
+		s.logger.Info("Woops Too Soon")
+		doAckBufSucceed(s, pkt.AckHandle, make([]byte, 1))
+		return
+	}
+
+	logs, err := s.server.mercenaryRepo.GetRecentKillLogs(uint32(rastaID), lastKillLog, 5)
+	if err != nil {
+		s.logger.Error("failed to fetch kill logs for mercenary huntdata", zap.Error(err), zap.Uint32("rastaID", uint32(rastaID)))
+		doAckBufSucceed(s, pkt.AckHandle, make([]byte, 1))
+		return
+	}
+
+	if len(logs) == 0 {
+		s.logger.Info("Woops No new Hunts")
+		doAckBufSucceed(s, pkt.AckHandle, make([]byte, 1))
+		return
+	}
+
+	var maxID uint32
+	for _, log := range logs {
+		if log.ID > maxID {
+			maxID = log.ID
+		}
+	}
+
+	if err := s.server.mercenaryRepo.InsertMercenaryReward(uint32(rastaID), maxID, midday); err != nil {
+		s.logger.Error("failed to insert mercenary claim", zap.Error(err), zap.Uint32("rastaID", uint32(rastaID)), zap.Uint32("killLogID", maxID))
+		doAckBufSucceed(s, pkt.AckHandle, make([]byte, 1))
+		return
+	}
+
+	bf := byteframe.NewByteFrame()
+	bf.WriteUint8(uint8(len(logs)))
+	for _, log := range logs {
+		bf.WriteUint32(log.ID)
+		bf.WriteUint32(log.Monster)
+	}
+
+	doAckBufSucceed(s, pkt.AckHandle, bf.Data())
 }
 
 func handleMsgMhfEnumerateMercenaryLog(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgMhfEnumerateMercenaryLog)
 	bf := byteframe.NewByteFrame()
-	bf.WriteUint32(0)
-	// Format:
-	// struct Log
-	//   uint32 Timestamp
-	//   []byte Name (len 18)
-	//   uint8 Unk
-	//   uint8 Unk
+
+	logs, err := s.server.mercenaryRepo.GetMercenaryLogs(s.charID)
+	if err != nil {
+		s.logger.Error("failed to fetch mercenary logs", zap.Error(err), zap.Uint32("charID", s.charID))
+		doAckBufSucceed(s, pkt.AckHandle, bf.Data())
+		return
+	}
+
+	bf.WriteUint32(uint32(len(logs)))
+	for _, l := range logs {
+		bf.WriteUint32(uint32(l.Date.Unix()))
+		bf.WriteBytes(stringsupport.PaddedString(l.Name, 18, true))
+
+		state := []byte{0, byte(l.State)}
+		if l.IsInitiator {
+			state[0] = 1
+		}
+		bf.WriteBytes(state)
+	}
+
 	doAckBufSucceed(s, pkt.AckHandle, bf.Data())
 }
 
@@ -186,26 +264,31 @@ func handleMsgMhfCreateMercenary(s *Session, p mhfpacket.MHFPacket) {
 
 func handleMsgMhfSaveMercenary(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgMhfSaveMercenary)
-	if len(pkt.MercData) > 65536 {
+
+	if len(pkt.MercData) > 0x8B {
 		s.logger.Warn("Mercenary payload too large", zap.Int("len", len(pkt.MercData)))
 		doAckSimpleSucceed(s, pkt.AckHandle, make([]byte, 4))
 		return
 	}
+
 	dumpSaveData(s, pkt.MercData, "mercenary")
-	if len(pkt.MercData) >= 4 {
-		temp := byteframe.NewByteFrameFromBytes(pkt.MercData)
-		rastaID := temp.ReadUint32()
-		if rastaID == 0 {
+
+	if len(pkt.MercData) == 0x8B {
+		if pkt.RastaMercID == 0 {
 			s.logger.Warn("Mercenary save with rasta_id=0, preserving existing value",
 				zap.Uint32("charID", s.charID))
 		}
-		if err := s.server.charRepo.SaveMercenary(s.charID, pkt.MercData, rastaID); err != nil {
+		if err := s.server.charRepo.SaveMercenary(s.charID, pkt.MercData, pkt.RastaMercID); err != nil {
 			s.logger.Error("Failed to save mercenary data", zap.Error(err))
 		}
+	} else {
+		s.logger.Warn("Mercenary payload too small", zap.Int("len", len(pkt.MercData)))
 	}
+
 	if err := s.server.charRepo.UpdateGCPAndPact(s.charID, pkt.GCP, pkt.PactMercID); err != nil {
 		s.logger.Error("Failed to update GCP and pact ID", zap.Error(err))
 	}
+
 	doAckSimpleSucceed(s, pkt.AckHandle, []byte{0x00, 0x00, 0x00, 0x00})
 }
 
@@ -217,20 +300,29 @@ func handleMsgMhfReadMercenaryW(s *Session, p mhfpacket.MHFPacket) {
 	if pactErr != nil {
 		s.logger.Warn("Failed to read pact_id", zap.Error(pactErr))
 	}
+
 	var cid uint32
 	var name string
 	if pactID > 0 {
 		var findErr error
-		cid, name, findErr = s.server.charRepo.FindByRastaID(pactID)
+		var contractDate sql.NullTime
+		cid, name, contractDate, findErr = s.server.charRepo.FindByRastaID(pactID, s.charID)
 		if findErr != nil {
 			s.logger.Warn("Failed to find character by rasta ID", zap.Error(findErr))
 		}
+
+		start := TimeAdjusted()
+		if contractDate.Valid {
+			start = contractDate.Time
+		}
+		expiry := start.Add(7 * 24 * time.Hour)
+
 		bf.WriteUint8(1) // numLends
 		bf.WriteUint32(uint32(pactID))
 		bf.WriteUint32(cid)
 		bf.WriteBool(true) // Escort enabled
-		bf.WriteUint32(uint32(TimeAdjusted().Unix()))
-		bf.WriteUint32(uint32(TimeAdjusted().Add(time.Hour * 24 * 7).Unix()))
+		bf.WriteUint32(uint32(start.Unix()))
+		bf.WriteUint32(uint32(expiry.Unix()))
 		bf.WriteBytes(stringsupport.PaddedString(name, 18, true))
 	} else {
 		bf.WriteUint8(0)
@@ -241,12 +333,19 @@ func handleMsgMhfReadMercenaryW(s *Session, p mhfpacket.MHFPacket) {
 		if err != nil {
 			s.logger.Error("Failed to query mercenary loans", zap.Error(err))
 		}
+
 		bf.WriteUint8(uint8(len(loans)))
 		for _, loan := range loans {
+			start := TimeAdjusted()
+			if loan.ContractDate.Valid {
+				start = loan.ContractDate.Time
+			}
+			expiry := start.Add(7 * 24 * time.Hour)
+
 			bf.WriteUint32(uint32(loan.PactID))
 			bf.WriteUint32(loan.CharID)
-			bf.WriteUint32(uint32(TimeAdjusted().Unix()))
-			bf.WriteUint32(uint32(TimeAdjusted().Add(time.Hour * 24 * 7).Unix()))
+			bf.WriteUint32(uint32(start.Unix()))
+			bf.WriteUint32(uint32(expiry.Unix()))
 			bf.WriteBytes(stringsupport.PaddedString(loan.Name, 18, true))
 		}
 
@@ -254,6 +353,10 @@ func handleMsgMhfReadMercenaryW(s *Session, p mhfpacket.MHFPacket) {
 			data, dataErr := s.server.charRepo.LoadColumn(s.charID, "savemercenary")
 			if dataErr != nil {
 				s.logger.Warn("Failed to load savemercenary", zap.Error(dataErr))
+			}
+			rastaid, rastaErr := readCharacterInt(s, "rasta_id")
+			if rastaErr != nil {
+				s.logger.Warn("Failed to read rasta_id", zap.Error(rastaErr))
 			}
 			gcp, gcpErr := readCharacterInt(s, "gcp")
 			if gcpErr != nil {
@@ -264,6 +367,9 @@ func handleMsgMhfReadMercenaryW(s *Session, p mhfpacket.MHFPacket) {
 				bf.WriteBool(false)
 			} else {
 				bf.WriteBool(true)
+				bf.WriteUint32(uint32(rastaid))
+				bf.WriteUint32(s.charID)
+				bf.WriteBool(true) // TODO: Load escort toggle state from DB.
 				bf.WriteBytes(data)
 			}
 			bf.WriteUint32(uint32(gcp))
@@ -273,6 +379,7 @@ func handleMsgMhfReadMercenaryW(s *Session, p mhfpacket.MHFPacket) {
 	doAckBufSucceed(s, pkt.AckHandle, bf.Data())
 }
 
+//This function load contracted mercenary data (triggered by mercenaryW if theres some contract)
 func handleMsgMhfReadMercenaryM(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgMhfReadMercenaryM)
 	data, err := s.server.charRepo.LoadColumn(pkt.CharID, "savemercenary")
@@ -283,6 +390,12 @@ func handleMsgMhfReadMercenaryM(s *Session, p mhfpacket.MHFPacket) {
 	if len(data) == 0 {
 		resp.WriteBool(false)
 	} else {
+		//mercenary header data
+		resp.WriteUint32(uint32(pkt.MercID))
+		resp.WriteUint32(uint32(pkt.CharID))
+		//hard code for now, should be in database to check rasta escort state (follow/not)
+		resp.WriteBool(true)
+		//mercenary savedata
 		resp.WriteBytes(data)
 	}
 	doAckBufSucceed(s, pkt.AckHandle, resp.Data())
@@ -290,20 +403,83 @@ func handleMsgMhfReadMercenaryM(s *Session, p mhfpacket.MHFPacket) {
 
 func handleMsgMhfContractMercenary(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgMhfContractMercenary)
+	now := TimeAdjusted()
+
 	switch pkt.Op {
 	case 0: // Form loan
-		if err := s.server.charRepo.SaveInt(pkt.CID, "pact_id", int(pkt.PactMercID)); err != nil {
-			s.logger.Error("Failed to form mercenary loan", zap.Error(err))
+		if err := s.server.charRepo.SetPact(pkt.CID, pkt.PactMercID, now); err != nil {
+			s.logger.Error("Failed to form mercenary loan",
+				zap.Uint32("charID", pkt.CID),
+				zap.Uint32("pactMercID", pkt.PactMercID),
+				zap.Error(err),
+			)
 		}
+		if err := s.server.mercenaryRepo.LogMercenaryEvent(s.charID, pkt.CID, now, true, 0); err != nil {
+			s.logger.Error("Failed to log mercenary event",
+				zap.Uint32("playerID", s.charID),
+				zap.Uint32("mercenaryID", pkt.CID),
+				zap.Int("state", 0),
+				zap.Error(err),
+			)
+		}
+		if err := s.server.mercenaryRepo.LogMercenaryEvent(pkt.CID, s.charID, now, false, 0); err != nil {
+			s.logger.Error("Failed to log mercenary event",
+				zap.Uint32("playerID", pkt.CID),
+				zap.Uint32("mercenaryID", s.charID),
+				zap.Int("state", 0),
+				zap.Error(err),
+			)
+		}
+
 	case 1: // Cancel lend
-		if err := s.server.charRepo.SaveInt(s.charID, "pact_id", 0); err != nil {
-			s.logger.Error("Failed to cancel mercenary lend", zap.Error(err))
+		if err := s.server.charRepo.ClearPact(s.charID); err != nil {
+			s.logger.Error("Failed to cancel mercenary lend",
+				zap.Uint32("charID", s.charID),
+				zap.Error(err),
+			)
 		}
-	case 2: // Cancel loan
-		if err := s.server.charRepo.SaveInt(pkt.CID, "pact_id", 0); err != nil {
-			s.logger.Error("Failed to cancel mercenary loan", zap.Error(err))
+		if err := s.server.mercenaryRepo.LogMercenaryEvent(pkt.CID, s.charID, now, true, 4); err != nil {
+			s.logger.Error("Failed to log mercenary event",
+				zap.Uint32("playerID", pkt.CID),
+				zap.Uint32("mercenaryID", s.charID),
+				zap.Int("state", 4),
+				zap.Error(err),
+			)
+		}
+		if err := s.server.mercenaryRepo.LogMercenaryEvent(s.charID, pkt.CID, now, false, 4); err != nil {
+			s.logger.Error("Failed to log mercenary event",
+				zap.Uint32("playerID", s.charID),
+				zap.Uint32("mercenaryID", pkt.CID),
+				zap.Int("state", 4),
+				zap.Error(err),
+			)
+		}
+
+	case 2: // Cancel loan - player terminate the backup contract
+		if err := s.server.charRepo.ClearPact(pkt.CID); err != nil {
+			s.logger.Error("Failed to cancel mercenary loan",
+				zap.Uint32("charID", pkt.CID),
+				zap.Error(err),
+			)
+		}
+		if err := s.server.mercenaryRepo.LogMercenaryEvent(pkt.CID, s.charID, now, false, 3); err != nil {
+			s.logger.Error("Failed to log mercenary event",
+				zap.Uint32("playerID", pkt.CID),
+				zap.Uint32("mercenaryID", s.charID),
+				zap.Int("state", 3),
+				zap.Error(err),
+			)
+		}
+		if err := s.server.mercenaryRepo.LogMercenaryEvent(s.charID, pkt.CID, now, true, 3); err != nil {
+			s.logger.Error("Failed to log mercenary event",
+				zap.Uint32("playerID", s.charID),
+				zap.Uint32("mercenaryID", pkt.CID),
+				zap.Int("state", 3),
+				zap.Error(err),
+			)
 		}
 	}
+
 	doAckSimpleSucceed(s, pkt.AckHandle, make([]byte, 4))
 }
 

--- a/server/channelserver/handlers_session.go
+++ b/server/channelserver/handlers_session.go
@@ -435,25 +435,46 @@ func handleMsgSysIssueLogkey(s *Session, p mhfpacket.MHFPacket) {
 
 const localhostAddrLE = uint32(0x0100007F) // 127.0.0.1 in little-endian
 
-// Kill log binary layout constants
-const (
-	killLogHeaderSize   = 32  // bytes before monster kill count array
-	killLogMonsterCount = 176 // monster table entries
-)
-
 // RP accrual rate constants (seconds per RP point)
 const (
 	rpAccrualNormal = 1800 // 30 min per RP without cafe
 	rpAccrualCafe   = 900  // 15 min per RP with cafe course
 )
 
+// Kill log binary layout constants
+func killLogLayout(mode cfg.Mode) (headerSize int, monsterCount int, ok bool) {
+	switch mode {
+	case cfg.ZZ:
+		return 32, 176, true
+	case cfg.G32:
+		return 28, 122, true
+	// Add newly discovered versions here, e.g.:
+	// case cfg.G3:
+	// 	return X, Y, true
+	default:
+		return 0, 0, false
+	}
+}
+
 func handleMsgSysRecordLog(s *Session, p mhfpacket.MHFPacket) {
 	pkt := p.(*mhfpacket.MsgSysRecordLog)
-	if s.server.erupeConfig.RealClientMode == cfg.ZZ {
+
+	headerSize, monsterCount, ok := killLogLayout(s.server.erupeConfig.RealClientMode)
+	if !ok {
+		// Unknown/unsupported client version for this packet layout.
+		// Skip parsing rather than risk reading garbage offsets.
+		s.logger.Warn("No kill log layout defined for client mode",
+			zap.Any("mode", s.server.erupeConfig.RealClientMode))
+	} else if monsterCount > len(mhfmon.Monsters) {
+		s.logger.Error("killLog monsterCount exceeds mhfmon.Monsters length",
+			zap.Int("monsterCount", monsterCount),
+			zap.Int("available", len(mhfmon.Monsters)))
+	} else {
 		bf := byteframe.NewByteFrameFromBytes(pkt.Data)
-		_, _ = bf.Seek(killLogHeaderSize, 0)
+		_, _ = bf.Seek(int64(headerSize), 0)
+
 		var val uint8
-		for i := 0; i < killLogMonsterCount; i++ {
+		for i := 0; i < monsterCount; i++ {
 			val = bf.ReadUint8()
 			if val > 0 && mhfmon.Monsters[i].Large {
 				if err := s.server.guildRepo.InsertKillLog(s.charID, i, val, TimeAdjusted()); err != nil {
@@ -462,6 +483,7 @@ func handleMsgSysRecordLog(s *Session, p mhfpacket.MHFPacket) {
 			}
 		}
 	}
+
 	// remove a client returning to town from reserved slots to make sure the stage is hidden from board
 	delete(s.stage.reservedClientSlots, s.charID)
 	doAckSimpleSucceed(s, pkt.AckHandle, make([]byte, 4))

--- a/server/channelserver/repo_character.go
+++ b/server/channelserver/repo_character.go
@@ -381,9 +381,13 @@ func (r *CharacterRepository) LoadSaveDataWithHash(charID uint32) (uint32, []byt
 	return id, savedata, isNew, name, hash, err
 }
 
-// FindByRastaID looks up name and id by rasta_id.
-func (r *CharacterRepository) FindByRastaID(rastaID int) (charID uint32, name string, err error) {
-	err = r.db.QueryRow("SELECT name, id FROM characters WHERE rasta_id=$1", rastaID).Scan(&name, &charID)
+// FindByRastaID looks up name, id, and the querying character's contract_date by rasta_id.
+func (r *CharacterRepository) FindByRastaID(rastaID int, selfID uint32) (charID uint32, name string, contractDate sql.NullTime, err error) {
+	err = r.db.QueryRow(`
+		SELECT c.name, c.id, (SELECT mercenary_contract_date FROM characters WHERE id = $2)
+		FROM characters c
+		WHERE c.rasta_id = $1
+	`, rastaID, selfID).Scan(&name, &charID, &contractDate)
 	return
 }
 
@@ -411,4 +415,17 @@ func (r *CharacterRepository) LoadSaveData(charID uint32) (uint32, []byte, bool,
 	err := r.db.QueryRow("SELECT id, savedata, is_new_character, name FROM characters WHERE id = $1", charID).
 		Scan(&id, &savedata, &isNew, &name)
 	return id, savedata, isNew, name, err
+}
+
+// SetPact sets pact_id and contract_date atomically (used when forming a mercenary loan).
+func (r *CharacterRepository) SetPact(charID uint32, pactID uint32, contractDate time.Time) error {
+	_, err := r.db.Exec(`UPDATE characters SET pact_id=$1, mercenary_contract_date=$2 WHERE id=$3`,
+		pactID, contractDate, charID)
+	return err
+}
+
+// ClearPact resets pact_id to 0 and clears contract_date (used when a lend/loan is cancelled).
+func (r *CharacterRepository) ClearPact(charID uint32) error {
+	_, err := r.db.Exec(`UPDATE characters SET pact_id=0, mercenary_contract_date=NULL WHERE id=$1`, charID)
+	return err
 }

--- a/server/channelserver/repo_interfaces.go
+++ b/server/channelserver/repo_interfaces.go
@@ -2,6 +2,8 @@ package channelserver
 
 import (
 	"time"
+	"database/sql" // ADD THIS
+
 )
 
 // Repository interfaces decouple handlers from concrete PostgreSQL implementations,
@@ -35,7 +37,7 @@ type CharacterRepo interface {
 	ReadGuildPostChecked(charID uint32) (time.Time, error)
 	SaveMercenary(charID uint32, data []byte, rastaID uint32) error
 	UpdateGCPAndPact(charID uint32, gcp uint32, pactID uint32) error
-	FindByRastaID(rastaID int) (charID uint32, name string, err error)
+	//FindByRastaID(rastaID int) (charID uint32, name string, err error)
 	SaveCharacterData(charID uint32, compSave []byte, hr, gr uint16, isFemale bool, weaponType uint8, weaponID uint16) error
 	SaveHouseData(charID uint32, houseTier []byte, houseData, bookshelf, gallery, tore, garden []byte) error
 	LoadSaveData(charID uint32) (uint32, []byte, bool, string, error)
@@ -51,6 +53,9 @@ type CharacterRepo interface {
 	// LoadBackupsByRecency returns all backup slots for a character ordered
 	// most-recent first. Returns an empty slice if no backups exist.
 	LoadBackupsByRecency(charID uint32) ([]SavedataBackup, error)
+	FindByRastaID(rastaID int, selfID uint32) (charID uint32, name string, contractDate sql.NullTime, err error)
+	SetPact(charID uint32, pactID uint32, contractDate time.Time) error
+	ClearPact(charID uint32) error
 }
 
 // GuildRepo defines the contract for guild data access.
@@ -401,6 +406,22 @@ type MercenaryRepo interface {
 	GetMercenaryLoans(charID uint32) ([]MercenaryLoan, error)
 	GetGuildHuntCatsUsed(charID uint32) ([]GuildHuntCatUsage, error)
 	GetGuildAirou(guildID uint32) ([][]byte, error)
+	// LogMercenaryEvent inserts a row into mercenary_logs recording a contract state change.
+	LogMercenaryEvent(playerID, mercenaryID uint32, logTime time.Time, isInitiator bool, state int) error
+
+	// GetMercenaryLogs returns the mercenary contract history for a character, most recent first.
+	GetMercenaryLogs(charID uint32) ([]MercenaryLogEntry, error)
+
+	// GetLastMercenaryReward returns the last claimed kill_log_id and claim time for a mercenary.
+	// If no reward row exists, sql.ErrNoRows is returned so callers can distinguish "first claim".
+	GetLastMercenaryReward(mercenaryID uint32, defaultClaim time.Time) (lastKillLogID uint32, lastClaimAt time.Time, err error)
+
+	// GetRecentKillLogs returns up to `limit` most recent distinct-monster kill logs for
+	// characters on loan to the given mercenary (rasta), with id greater than afterID.
+	GetRecentKillLogs(rastaID uint32, afterID uint32, limit int) ([]MercenaryKillLog, error)
+
+	// InsertMercenaryReward records a new reward claim checkpoint for a mercenary.
+	InsertMercenaryReward(mercenaryID, lastKillLogID uint32, claimAt time.Time) error
 }
 
 // Tournament represents a tournament schedule entry.

--- a/server/channelserver/repo_mercenary.go
+++ b/server/channelserver/repo_mercenary.go
@@ -1,6 +1,7 @@
 package channelserver
 
 import (
+	"database/sql" // ADD THIS
 	"fmt"
 	"time"
 
@@ -33,14 +34,15 @@ func (r *MercenaryRepository) NextAirouID() (uint32, error) {
 
 // MercenaryLoan represents a character that has a pact with a rasta.
 type MercenaryLoan struct {
-	Name   string
-	CharID uint32
-	PactID int
+	Name         string
+	CharID       uint32
+	PactID       int
+	ContractDate sql.NullTime
 }
 
 // GetMercenaryLoans returns characters that have a pact with the given character's rasta_id.
 func (r *MercenaryRepository) GetMercenaryLoans(charID uint32) ([]MercenaryLoan, error) {
-	rows, err := r.db.Query("SELECT name, id, pact_id FROM characters WHERE pact_id=(SELECT rasta_id FROM characters WHERE id=$1)", charID)
+	rows, err := r.db.Query("SELECT name, id, pact_id, mercenary_contract_date FROM characters WHERE pact_id=(SELECT rasta_id FROM characters WHERE id=$1)", charID)
 	if err != nil {
 		return nil, fmt.Errorf("query mercenary loans: %w", err)
 	}
@@ -48,7 +50,7 @@ func (r *MercenaryRepository) GetMercenaryLoans(charID uint32) ([]MercenaryLoan,
 	var result []MercenaryLoan
 	for rows.Next() {
 		var l MercenaryLoan
-		if err := rows.Scan(&l.Name, &l.CharID, &l.PactID); err != nil {
+		if err := rows.Scan(&l.Name, &l.CharID, &l.PactID, &l.ContractDate); err != nil {
 			return nil, fmt.Errorf("scan mercenary loan: %w", err)
 		}
 		result = append(result, l)
@@ -100,4 +102,104 @@ func (r *MercenaryRepository) GetGuildAirou(guildID uint32) ([][]byte, error) {
 		result = append(result, data)
 	}
 	return result, rows.Err()
+}
+
+// LogMercenaryEvent inserts a row into mercenary_logs recording a contract state change.
+func (r *MercenaryRepository) LogMercenaryEvent(playerID, mercenaryID uint32, logTime time.Time, isInitiator bool, state int) error {
+	_, err := r.db.Exec(`
+		INSERT INTO mercenary_logs(player_id, mercenary_id, log_time, is_initiator, state)
+		VALUES ($1, $2, $3, $4, $5)
+	`, playerID, mercenaryID, logTime, isInitiator, state)
+	return err
+}
+
+// MercenaryKillLog represents an aggregated kill-log entry for a mercenary reward claim.
+type MercenaryKillLog struct {
+	ID      uint32 `db:"id"`
+	Monster uint32 `db:"monster"`
+}
+
+// GetLastMercenaryReward returns the last claimed kill_log_id and claim time for a mercenary.
+// If no reward row exists, sql.ErrNoRows is returned so callers can distinguish "first claim".
+func (r *MercenaryRepository) GetLastMercenaryReward(mercenaryID uint32, defaultClaim time.Time) (lastKillLogID uint32, lastClaimAt time.Time, err error) {
+	err = r.db.QueryRow(`
+		SELECT COALESCE(last_kill_log_id, 0), COALESCE(last_claim_at, $2)
+		FROM mercenary_rewards
+		WHERE mercenary_id = $1
+		ORDER BY last_claim_at DESC
+		LIMIT 1
+	`, mercenaryID, defaultClaim).Scan(&lastKillLogID, &lastClaimAt)
+	return
+}
+
+// GetRecentKillLogs returns up to `limit` most recent distinct-monster kill logs for
+// characters on loan to the given mercenary (rasta), with id greater than afterID.
+func (r *MercenaryRepository) GetRecentKillLogs(rastaID uint32, afterID uint32, limit int) ([]MercenaryKillLog, error) {
+	rows, err := r.db.Queryx(`
+		SELECT MAX(id) AS id, monster
+		FROM kill_logs
+		WHERE character_id IN (
+			SELECT id FROM characters WHERE pact_id = $1
+		)
+		AND id > $2
+		GROUP BY monster
+		ORDER BY MAX(timestamp) DESC
+		LIMIT $3
+	`, rastaID, afterID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query recent kill logs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var logs []MercenaryKillLog
+	for rows.Next() {
+		var log MercenaryKillLog
+		if err := rows.StructScan(&log); err != nil {
+			return nil, fmt.Errorf("scan kill log row: %w", err)
+		}
+		logs = append(logs, log)
+	}
+	return logs, rows.Err()
+}
+
+// InsertMercenaryReward records a new reward claim checkpoint for a mercenary.
+func (r *MercenaryRepository) InsertMercenaryReward(mercenaryID, lastKillLogID uint32, claimAt time.Time) error {
+	_, err := r.db.Exec(`
+		INSERT INTO mercenary_rewards (mercenary_id, last_kill_log_id, last_claim_at)
+		VALUES ($1, $2, $3)
+	`, mercenaryID, lastKillLogID, claimAt)
+	return err
+}
+
+// MercenaryLogEntry represents one contract-history entry for a character.
+type MercenaryLogEntry struct {
+	Name        string
+	Date        time.Time
+	IsInitiator bool
+	State       uint16
+}
+
+// GetMercenaryLogs returns the mercenary contract history for a character, most recent first.
+func (r *MercenaryRepository) GetMercenaryLogs(charID uint32) ([]MercenaryLogEntry, error) {
+	rows, err := r.db.Query(`
+		SELECT COALESCE(c.name, ''), ml.log_time, ml.is_initiator, ml.state
+		FROM mercenary_logs ml
+		LEFT JOIN characters c ON c.id = ml.mercenary_id
+		WHERE ml.player_id = $1
+		ORDER BY ml.log_time DESC
+	`, charID)
+	if err != nil {
+		return nil, fmt.Errorf("query mercenary logs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var logs []MercenaryLogEntry
+	for rows.Next() {
+		var l MercenaryLogEntry
+		if err := rows.Scan(&l.Name, &l.Date, &l.IsInitiator, &l.State); err != nil {
+			return nil, fmt.Errorf("scan mercenary log row: %w", err)
+		}
+		logs = append(logs, l)
+	}
+	return logs, rows.Err()
 }

--- a/server/channelserver/sys_session.go
+++ b/server/channelserver/sys_session.go
@@ -232,20 +232,29 @@ func (s *Session) QueueAck(ackHandle uint32, data []byte) {
 }
 
 func (s *Session) sendLoop() {
-	for {
-		if s.closed.Load() {
-			return
-		}
-		// Send each packet individually with its own terminator
-		for len(s.sendPackets) > 0 {
-			pkt := <-s.sendPackets
-			err := s.cryptConn.SendPacket(append(pkt.data, []byte{0x00, 0x10}...))
-			if err != nil {
-				s.logger.Warn("Failed to send packet", zap.Error(err))
-			}
-		}
-		time.Sleep(time.Duration(s.server.erupeConfig.LoopDelay) * time.Millisecond)
-	}
+    var pkt packet
+    var buffer []byte
+
+    for {
+        if s.closed.Load() {
+            return
+        }
+
+        for len(s.sendPackets) > 0 {
+            pkt = <-s.sendPackets
+            buffer = append(buffer, pkt.data...)
+        }
+
+        if len(buffer) > 0 {
+            err := s.cryptConn.SendPacket(append(buffer, 0x00, 0x10))
+            if err != nil {
+                s.logger.Warn("Failed to send packet", zap.Error(err))
+            }
+            buffer = buffer[:0]
+        }
+
+        time.Sleep(time.Duration(s.server.erupeConfig.LoopDelay) * time.Millisecond)
+    }
 }
 
 func (s *Session) recvLoop() {

--- a/server/migrations/sql/0001_init.sql
+++ b/server/migrations/sql/0001_init.sql
@@ -221,6 +221,7 @@ CREATE TABLE public.characters (
     promo_points integer DEFAULT 0 NOT NULL,
     rasta_id integer,
     pact_id integer,
+    mercenary_contract_date timestamp with time zone,
     stampcard integer DEFAULT 0 NOT NULL,
     mezfes bytea
 );
@@ -1119,6 +1120,68 @@ CREATE SEQUENCE public.mail_id_seq
 ALTER SEQUENCE public.mail_id_seq OWNED BY public.mail.id;
 
 
+CREATE TABLE public.mercenary_logs (
+    id integer NOT NULL,
+    player_id integer,
+    mercenary_id integer,
+    log_time timestamp with time zone,
+    is_initiator boolean DEFAULT false NOT NULL,
+    state smallint DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: mercenary_logs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.mercenary_logs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: mercenary_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.mercenary_logs_id_seq OWNED BY public.mercenary_logs.id;
+
+
+--
+-- Name: mercenary_rewards; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.mercenary_rewards (
+    id integer NOT NULL,
+    mercenary_id integer NOT NULL,
+    last_kill_log_id integer,
+    last_claim_at timestamp with time zone
+);
+
+
+--
+-- Name: mercenary_rewards_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.mercenary_rewards_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: mercenary_rewards_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.mercenary_rewards_id_seq OWNED BY public.mercenary_rewards.id;
+
+
 --
 -- Name: rasta_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
@@ -1131,9 +1194,6 @@ CREATE SEQUENCE public.rasta_id_seq
     CACHE 1;
 
 
---
--- Name: rengoku_score; Type: TABLE; Schema: public; Owner: -
---
 
 CREATE TABLE public.rengoku_score (
     character_id integer NOT NULL,

--- a/server/migrations/sql/0010_fix_zero_rasta_id.sql
+++ b/server/migrations/sql/0010_fix_zero_rasta_id.sql
@@ -3,3 +3,25 @@
 -- causes silent save failures on affected characters (see #163).
 -- The normal default for characters that never registered a mercenary is NULL.
 UPDATE public.characters SET rasta_id = NULL WHERE rasta_id = 0;
+
+ALTER TABLE public.mercenary_logs
+    ALTER COLUMN id SET DEFAULT nextval('public.mercenary_logs_id_seq'::regclass);
+
+SELECT setval('public.mercenary_logs_id_seq', COALESCE((SELECT MAX(id) FROM public.mercenary_logs), 0) + 1, false);
+
+BEGIN;
+
+-- strip the first 0x9 (9) bytes, leaving a 0x8b (139) byte payload.
+UPDATE characters
+SET savemercenary = substring(savemercenary FROM 10)
+WHERE octet_length(savemercenary) = 148;
+
+-- Step 2: anything that still isn't exactly 0x8b (139) bytes after that
+-- is in an unexpected/corrupt shape — null it out rather than leave
+-- a blob the client will misparse.
+UPDATE characters
+SET savemercenary = NULL
+WHERE savemercenary IS NOT NULL
+  AND octet_length(savemercenary) <> 139;
+
+COMMIT;


### PR DESCRIPTION
-reimplement wish sys_session so contract can be triggered
-removed and parsed rasta id and characters id from mercenary packet
-implement mercenary log feature
-implement mercenary reward feature (g3.2 and zz only)
-kill logs now work on G3.2
-can be improved

found the kill_logs header_address in G3.2 while researching mercenary reward for fiver server. plan to find for other version if i have time

currently tested on : 
ZZ
G3.2

credit for seleszi for testing extensively on G3.2