### PR TITLE
fix(rengoku): write real spawn candidate counts, add spawn pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `BuildRengokuBinary` (JSON Hunting Road config) left the per-slot spawn candidate count array zeroed, so any server using `rengoku_data.json` served a binary that instantly crashed real clients on Hunting Road entry ([#206](https://github.com/Mezeporta/Erupe/issues/206)). The flat `spawn_tables` schema also couldn't represent retail's multi-candidate spawn slots. Replaced it with `spawn_pools` (`RoadConfig.SpawnPools [][]SpawnTableConfig`) — each floor's `spawn_table_index` now selects a pool of candidates the client rolls between via `spawn_weighting` — and `writeSpawnSection` now writes real per-slot counts (`len(pool)`, always >= 1). `validateRengokuConfig` rejects empty pools before building, and `parseRengokuBinary` now reads the count array and rejects zero-count slots instead of only checking pointer bounds, so a broken build can no longer pass structural validation silently.
+
 ### Removed
 
 - `stable/v9.2.x` branch and its `SECURITY.md` supported-version entry — the branch had been untouched since 2026-02-08 and 9.2.x is well past the current 9.4.x release line.

--- a/cmd/protbot/main.go
+++ b/cmd/protbot/main.go
@@ -20,13 +20,14 @@ import (
 	"time"
 
 	"erupe-ce/cmd/protbot/scenario"
+	"erupe-ce/common/decryption"
 )
 
 func main() {
 	signAddr := flag.String("sign-addr", "127.0.0.1:53312", "Sign server address (host:port)")
 	user := flag.String("user", "", "Username")
 	pass := flag.String("pass", "", "Password")
-	action := flag.String("action", "login", "Action to perform: login, lobby, session, chat, quests, achievement, boost, gacha")
+	action := flag.String("action", "login", "Action to perform: login, lobby, session, chat, quests, achievement, boost, gacha, rengoku")
 	message := flag.String("message", "", "Chat message to send (used with --action chat)")
 	gachaID := flag.Uint("gacha-id", 1, "Gacha ID to roll (used with --action gacha)")
 	rollType := flag.Uint("roll-type", 0, "Gacha roll type: 0=single, 1=ten-pull (used with --action gacha)")
@@ -329,8 +330,71 @@ func main() {
 		}
 		_ = scenario.Logout(result.Channel)
 
+	case "rengoku":
+		result, err := scenario.Login(*signAddr, *user, *pass)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "login failed: %v\n", err)
+			os.Exit(1)
+		}
+		charID := result.Sign.CharIDs[0]
+		if _, err := scenario.SetupSession(result.Channel, charID); err != nil {
+			fmt.Fprintf(os.Stderr, "session setup failed: %v\n", err)
+			_ = result.Channel.Close()
+			os.Exit(1)
+		}
+		if err := scenario.EnterLobby(result.Channel); err != nil {
+			fmt.Fprintf(os.Stderr, "enter lobby failed: %v\n", err)
+			_ = result.Channel.Close()
+			os.Exit(1)
+		}
+
+		// Regression check for #206: fetch the Hunting Road binary exactly as
+		// the real client would, then verify no spawn slot has a zero
+		// candidate count (which crashes the client on Hunting Road entry).
+		raw, err := scenario.GetRengokuBinary(result.Channel)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "get rengoku binary failed: %v\n", err)
+			_ = scenario.Logout(result.Channel)
+			os.Exit(1)
+		}
+		fmt.Printf("[rengoku] Received %d bytes (ECD-encrypted)\n", len(raw))
+
+		decrypted, err := decryption.DecodeECD(raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ECD decode failed: %v\n", err)
+			_ = scenario.Logout(result.Channel)
+			os.Exit(1)
+		}
+		fmt.Printf("[rengoku] Decrypted %d bytes\n", len(decrypted))
+
+		roadModes, err := scenario.VerifyRengokuBinary(decrypted)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "rengoku binary verification failed: %v\n", err)
+			_ = scenario.Logout(result.Channel)
+			os.Exit(1)
+		}
+
+		allOK := true
+		for _, rm := range roadModes {
+			fmt.Printf("[rengoku] %s: %d slot(s), candidate counts=%v\n", rm.Label, len(rm.SlotCounts), rm.SlotCounts)
+			for i, c := range rm.SlotCounts {
+				if c == 0 {
+					allOK = false
+					fmt.Printf("[rengoku]   slot %d has a ZERO candidate count — real client would crash here (#206)\n", i)
+				}
+			}
+		}
+		if allOK {
+			fmt.Println("[rengoku] All spawn slots have >= 1 candidate — #206 fix OK")
+		} else {
+			fmt.Println("[rengoku] FAIL: at least one spawn slot has a zero candidate count")
+			_ = scenario.Logout(result.Channel)
+			os.Exit(1)
+		}
+		_ = scenario.Logout(result.Channel)
+
 	default:
-		fmt.Fprintf(os.Stderr, "unknown action: %s (supported: login, lobby, session, chat, quests, achievement, boost, gacha)\n", *action)
+		fmt.Fprintf(os.Stderr, "unknown action: %s (supported: login, lobby, session, chat, quests, achievement, boost, gacha, rengoku)\n", *action)
 		os.Exit(1)
 	}
 }

--- a/cmd/protbot/protocol/opcodes.go
+++ b/cmd/protbot/protocol/opcodes.go
@@ -36,4 +36,7 @@ const (
 	MSG_MHF_GET_GACHA_POINT    uint16 = 0x0131
 	MSG_MHF_RECEIVE_GACHA_ITEM uint16 = 0x0137
 	MSG_MHF_PLAY_NORMAL_GACHA  uint16 = 0x0150
+
+	// Hunting Road / Rengoku (issue #206)
+	MSG_MHF_GET_RENGOKU_BINARY uint16 = 0x0197
 )

--- a/cmd/protbot/protocol/packets.go
+++ b/cmd/protbot/protocol/packets.go
@@ -304,6 +304,11 @@ func BuildGetGachaPointPacket(ackHandle uint32) []byte {
 	return BuildSimpleAckPacket(MSG_MHF_GET_GACHA_POINT, ackHandle)
 }
 
+// BuildGetRengokuBinaryPacket builds a MSG_MHF_GET_RENGOKU_BINARY packet.
+func BuildGetRengokuBinaryPacket(ackHandle uint32) []byte {
+	return BuildSimpleAckPacket(MSG_MHF_GET_RENGOKU_BINARY, ackHandle)
+}
+
 // BuildPlayNormalGachaPacket builds a MSG_MHF_PLAY_NORMAL_GACHA packet.
 // Layout mirrors Erupe's MsgMhfPlayNormalGacha.Parse:
 //

--- a/cmd/protbot/scenario/rengoku.go
+++ b/cmd/protbot/scenario/rengoku.go
@@ -1,0 +1,73 @@
+package scenario
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"erupe-ce/cmd/protbot/protocol"
+)
+
+// GetRengokuBinary sends MSG_MHF_GET_RENGOKU_BINARY and returns the raw
+// ECD-encrypted Hunting Road binary exactly as served to the real client
+// (regression check for #206: spawn slots must never carry a zero candidate
+// count, or the real client crashes on Hunting Road entry).
+func GetRengokuBinary(ch *protocol.ChannelConn) ([]byte, error) {
+	ack := ch.NextAckHandle()
+	pkt := protocol.BuildGetRengokuBinaryPacket(ack)
+	fmt.Printf("[rengoku] Sending GET_RENGOKU_BINARY (ackHandle=%d)...\n", ack)
+	if err := ch.SendPacket(pkt); err != nil {
+		return nil, fmt.Errorf("get rengoku binary send: %w", err)
+	}
+	resp, err := ch.WaitForAck(ack, 10*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("get rengoku binary ack: %w", err)
+	}
+	if resp.ErrorCode != 0 {
+		return nil, fmt.Errorf("get rengoku binary failed: error code %d", resp.ErrorCode)
+	}
+	return resp.Data, nil
+}
+
+// RengokuSlotCounts holds the per-slot candidate counts read back from one
+// road mode (multiDef or soloDef) of a decrypted rengoku binary.
+type RengokuSlotCounts struct {
+	Label      string
+	SlotCounts []uint32
+}
+
+// VerifyRengokuBinary reads the per-slot spawn candidate counts out of a
+// decrypted rengoku binary for both road modes, mirroring the layout
+// documented in server/channelserver/rengoku_binary.go (RoadMode struct:
+// floorStatsCount, spawnCountCount, spawnTablePtrCount, floorStatsPtr,
+// spawnTablePtrsPtr, spawnCountPtrsPtr — 6 x u32 starting at 0x14/0x2C).
+// It is a standalone reader (parseRengokuBinary itself is unexported in the
+// channelserver package) used to confirm, from the client's point of view,
+// that no slot ever carries a zero count (issue #206: a zero count crashes
+// the real client on Hunting Road entry).
+func VerifyRengokuBinary(data []byte) ([]RengokuSlotCounts, error) {
+	const rengokuMinSize = 0x44
+	if len(data) < rengokuMinSize {
+		return nil, fmt.Errorf("rengoku binary too small: %d bytes (need %d)", len(data), rengokuMinSize)
+	}
+	if data[0] != 'r' || data[1] != 'e' || data[2] != 'f' || data[3] != 0x1A {
+		return nil, fmt.Errorf("bad magic: %02x %02x %02x %02x", data[0], data[1], data[2], data[3])
+	}
+
+	le := binary.LittleEndian
+	var results []RengokuSlotCounts
+	for _, rm := range []struct {
+		label  string
+		offset int
+	}{{"multiDef", 0x14}, {"soloDef", 0x2C}} {
+		slotCount := le.Uint32(data[rm.offset+8:])
+		countPtrsPtr := le.Uint32(data[rm.offset+20:])
+
+		counts := make([]uint32, slotCount)
+		for i := uint32(0); i < slotCount; i++ {
+			counts[i] = le.Uint32(data[countPtrsPtr+i*4:])
+		}
+		results = append(results, RengokuSlotCounts{Label: rm.label, SlotCounts: counts})
+	}
+	return results, nil
+}

--- a/server/channelserver/rengoku_binary.go
+++ b/server/channelserver/rengoku_binary.go
@@ -144,37 +144,51 @@ func validateRoadMode(data []byte, rm rengokuRoadMode, label string) error {
 			label, rm.SpawnCountPtrsPtr, rm.SpawnCountCount, fileLen)
 	}
 
-	// Individual spawn-table pointer targets.
+	// Individual spawn slots: each slot's candidate count must be >= 1 (a
+	// zero count crashes the real client on Hunting Road entry), and the
+	// slot's candidate-table range (tablePtr .. tablePtr+count*32) must fit
+	// within the file.
 	ptrBase := rm.SpawnTablePtrsPtr
+	cntBase := rm.SpawnCountPtrsPtr
 	for i := uint32(0); i < rm.SpawnTablePtrCount; i++ {
 		tablePtr := binary.LittleEndian.Uint32(data[ptrBase+i*4:])
-		if !ptrInBounds(data, tablePtr, spawnTableByteSize) {
-			return fmt.Errorf("rengoku: %s: spawnTable[%d] at 0x%X is out of bounds (file %d B)",
-				label, i, tablePtr, fileLen)
+		count := binary.LittleEndian.Uint32(data[cntBase+i*4:])
+		if count == 0 {
+			return fmt.Errorf("rengoku: %s: spawn slot %d has zero candidate count (client crashes on this slot)",
+				label, i)
+		}
+		if !ptrInBounds(data, tablePtr, count*spawnTableByteSize) {
+			return fmt.Errorf("rengoku: %s: spawnTable[%d] pool [0x%X, +%d×%d] out of bounds (file %d B)",
+				label, i, tablePtr, count, spawnTableByteSize, fileLen)
 		}
 	}
 
 	return nil
 }
 
-// countUniqueMonsters iterates all SpawnTables for a RoadMode and returns a
-// set of unique non-zero monster IDs (from both monsterID1 and monsterID2).
+// countUniqueMonsters iterates every candidate table across all spawn pools
+// for a RoadMode and returns a set of unique non-zero monster IDs (from both
+// monsterID1 and monsterID2).
 func countUniqueMonsters(data []byte, rm rengokuRoadMode) map[uint32]struct{} {
 	ids := make(map[uint32]struct{})
 	ptrBase := rm.SpawnTablePtrsPtr
+	cntBase := rm.SpawnCountPtrsPtr
 	for i := uint32(0); i < rm.SpawnTablePtrCount; i++ {
 		tablePtr := binary.LittleEndian.Uint32(data[ptrBase+i*4:])
-		if !ptrInBounds(data, tablePtr, spawnTableByteSize) {
+		count := binary.LittleEndian.Uint32(data[cntBase+i*4:])
+		if !ptrInBounds(data, tablePtr, count*spawnTableByteSize) {
 			continue
 		}
-		t := data[tablePtr:]
-		id1 := binary.LittleEndian.Uint32(t[0:])
-		id2 := binary.LittleEndian.Uint32(t[8:])
-		if id1 != 0 {
-			ids[id1] = struct{}{}
-		}
-		if id2 != 0 {
-			ids[id2] = struct{}{}
+		for j := uint32(0); j < count; j++ {
+			t := data[tablePtr+j*spawnTableByteSize:]
+			id1 := binary.LittleEndian.Uint32(t[0:])
+			id2 := binary.LittleEndian.Uint32(t[8:])
+			if id1 != 0 {
+				ids[id1] = struct{}{}
+			}
+			if id2 != 0 {
+				ids[id2] = struct{}{}
+			}
 		}
 	}
 	return ids

--- a/server/channelserver/rengoku_binary_test.go
+++ b/server/channelserver/rengoku_binary_test.go
@@ -55,6 +55,8 @@ func buildRengokuData(multiMonster1, multiMonster2, soloMonster1, soloMonster2 u
 
 	// multiDef spawnTablePtrs at 0x5C: points to SpawnTable at 0x68
 	le.PutUint32(buf[0x5C:], 0x68)
+	// multiDef spawnCountPtrs at 0x64: 1 candidate in this slot
+	le.PutUint32(buf[0x64:], 1)
 
 	// multiDef SpawnTable at 0x68 (32 bytes)
 	le.PutUint32(buf[0x68:], multiMonster1)
@@ -65,6 +67,8 @@ func buildRengokuData(multiMonster1, multiMonster2, soloMonster1, soloMonster2 u
 
 	// soloDef spawnTablePtrs at 0xA0: points to SpawnTable at 0xA8
 	le.PutUint32(buf[0xA0:], 0xA8)
+	// soloDef spawnCountPtrs at 0xA4: 1 candidate in this slot
+	le.PutUint32(buf[0xA4:], 1)
 
 	// soloDef SpawnTable at 0xA8 (32 bytes)
 	le.PutUint32(buf[0xA8:], soloMonster1)
@@ -165,6 +169,18 @@ func TestParseRengokuBinary_Errors(t *testing.T) {
 				return d
 			}(),
 			wantErr: "out of bounds",
+		},
+		{
+			// Regression for #206: a zeroed candidate count must be rejected
+			// rather than silently accepted, since it crashes the real client.
+			name: "zero_spawn_count",
+			data: func() []byte {
+				d := make([]byte, len(validData))
+				copy(d, validData)
+				binary.LittleEndian.PutUint32(d[0x64:], 0) // multiDef spawnCountPtrs[0]
+				return d
+			}(),
+			wantErr: "zero candidate count",
 		},
 	}
 

--- a/server/channelserver/rengoku_build.go
+++ b/server/channelserver/rengoku_build.go
@@ -8,15 +8,20 @@ package channelserver
 	precedence: it is parsed, validated, assembled into the raw binary layout,
 	and ECD-encrypted before being cached. The .bin file is used as a fallback.
 
+	Each spawn slot (referenced by a floor's SpawnTableIndex) holds a *pool* of
+	candidate spawn tables — the real client rolls one candidate per slot using
+	each candidate's spawn_weighting, so a slot's count must be >= 1. A pool of
+	size 1 is a valid degenerate case (fixed spawn, no rolling).
+
 	Binary layout produced by BuildRengokuBinary:
 	  0x00–0x13  header  (20 bytes: magic + version + zeros)
 	  0x14–0x2B  multiDef RoadMode  (24 bytes)
 	  0x2C–0x43  soloDef  RoadMode  (24 bytes)
 	  -- multi road data --
 	  floorStats[]          (floorStatsCount × 24 bytes)
-	  spawnTablePtrs[]      (spawnTablePtrCount × 4 bytes)
-	  spawnCountPtrs[]      (spawnTablePtrCount × 4 bytes, zeroed)
-	  spawnTables[]         (spawnTablePtrCount × 32 bytes)
+	  spawnTablePtrs[]      (slotCount × 4 bytes — ptr to each slot's first candidate)
+	  spawnCountPtrs[]      (slotCount × 4 bytes — candidate count per slot, >= 1)
+	  spawnTables[]         (Σ pool sizes × 32 bytes, pools stored back to back)
 	  -- solo road data --  (same sub-layout)
 */
 
@@ -42,16 +47,18 @@ type RengokuConfig struct {
 }
 
 // RoadConfig describes one road mode (multi or solo) with its floors and
-// spawn tables. Floors reference spawn tables by zero-based index.
+// spawn pools. Floors reference spawn pools by zero-based index.
 type RoadConfig struct {
-	Floors      []FloorConfig      `json:"floors"`
-	SpawnTables []SpawnTableConfig `json:"spawn_tables"`
+	Floors     []FloorConfig        `json:"floors"`
+	SpawnPools [][]SpawnTableConfig `json:"spawn_pools"`
 }
 
 // FloorConfig describes one floor within a road mode.
 //
-//   - SpawnTableIndex: zero-based index into this road's SpawnTables slice,
-//     selecting which monster configuration is active on this floor.
+//   - SpawnTableIndex: zero-based index into this road's SpawnPools slice,
+//     selecting which pool of candidate monster configurations is active on
+//     this floor. The client rolls one candidate from the pool per spawn,
+//     weighted by each candidate's SpawnWeighting.
 //   - PointMulti1/2: point multipliers applied to rewards on this floor.
 //   - FinalLoop: non-zero on the last floor of a loop cycle.
 type FloorConfig struct {
@@ -89,25 +96,30 @@ func BuildRengokuBinary(cfg RengokuConfig) ([]byte, error) {
 	// Fixed regions: header (0x14) + two RoadModes (2×24) = 0x44
 	const dataStart = uint32(rengokuMinSize) // 0x44
 
+	mSlotCount := uint32(len(cfg.MultiRoad.SpawnPools))
+	mCandidateCount := countCandidates(cfg.MultiRoad.SpawnPools)
+	sSlotCount := uint32(len(cfg.SoloRoad.SpawnPools))
+	sCandidateCount := countCandidates(cfg.SoloRoad.SpawnPools)
+
 	// Multi road sections
 	mFloorOff := dataStart
 	mFloorSz := uint32(len(cfg.MultiRoad.Floors)) * floorStatsByteSize
 	mPtrsOff := mFloorOff + mFloorSz
-	mPtrsSz := uint32(len(cfg.MultiRoad.SpawnTables)) * spawnPtrEntrySize
+	mPtrsSz := mSlotCount * spawnPtrEntrySize
 	mCntOff := mPtrsOff + mPtrsSz
-	mCntSz := uint32(len(cfg.MultiRoad.SpawnTables)) * spawnPtrEntrySize
+	mCntSz := mSlotCount * spawnPtrEntrySize
 	mTablesOff := mCntOff + mCntSz
-	mTablesSz := uint32(len(cfg.MultiRoad.SpawnTables)) * spawnTableByteSize
+	mTablesSz := mCandidateCount * spawnTableByteSize
 
 	// Solo road sections (appended directly after multi)
 	sFloorOff := mTablesOff + mTablesSz
 	sFloorSz := uint32(len(cfg.SoloRoad.Floors)) * floorStatsByteSize
 	sPtrsOff := sFloorOff + sFloorSz
-	sPtrsSz := uint32(len(cfg.SoloRoad.SpawnTables)) * spawnPtrEntrySize
+	sPtrsSz := sSlotCount * spawnPtrEntrySize
 	sCntOff := sPtrsOff + sPtrsSz
-	sCntSz := uint32(len(cfg.SoloRoad.SpawnTables)) * spawnPtrEntrySize
+	sCntSz := sSlotCount * spawnPtrEntrySize
 	sTablesOff := sCntOff + sCntSz
-	sTablesSz := uint32(len(cfg.SoloRoad.SpawnTables)) * spawnTableByteSize
+	sTablesSz := sCandidateCount * spawnTableByteSize
 
 	totalSize := sTablesOff + sTablesSz
 	buf := make([]byte, totalSize)
@@ -121,16 +133,16 @@ func BuildRengokuBinary(cfg RengokuConfig) ([]byte, error) {
 	// ── RoadMode structs ─────────────────────────────────────────────────────
 	writeRoadMode(buf, 0x14, le, RoadModeFields{
 		FloorCount:   uint32(len(cfg.MultiRoad.Floors)),
-		SpawnCount:   uint32(len(cfg.MultiRoad.SpawnTables)),
-		TablePtrCnt:  uint32(len(cfg.MultiRoad.SpawnTables)),
+		SpawnCount:   mSlotCount,
+		TablePtrCnt:  mSlotCount,
 		FloorPtr:     mFloorOff,
 		TablePtrsPtr: mPtrsOff,
 		CountPtrsPtr: mCntOff,
 	})
 	writeRoadMode(buf, 0x2C, le, RoadModeFields{
 		FloorCount:   uint32(len(cfg.SoloRoad.Floors)),
-		SpawnCount:   uint32(len(cfg.SoloRoad.SpawnTables)),
-		TablePtrCnt:  uint32(len(cfg.SoloRoad.SpawnTables)),
+		SpawnCount:   sSlotCount,
+		TablePtrCnt:  sSlotCount,
 		FloorPtr:     sFloorOff,
 		TablePtrsPtr: sPtrsOff,
 		CountPtrsPtr: sCntOff,
@@ -138,12 +150,22 @@ func BuildRengokuBinary(cfg RengokuConfig) ([]byte, error) {
 
 	// ── Data sections ────────────────────────────────────────────────────────
 	writeFloors(buf, cfg.MultiRoad.Floors, mFloorOff, le)
-	writeSpawnSection(buf, cfg.MultiRoad.SpawnTables, mPtrsOff, mTablesOff, le)
+	writeSpawnSection(buf, cfg.MultiRoad.SpawnPools, mPtrsOff, mCntOff, mTablesOff, le)
 
 	writeFloors(buf, cfg.SoloRoad.Floors, sFloorOff, le)
-	writeSpawnSection(buf, cfg.SoloRoad.SpawnTables, sPtrsOff, sTablesOff, le)
+	writeSpawnSection(buf, cfg.SoloRoad.SpawnPools, sPtrsOff, sCntOff, sTablesOff, le)
 
 	return buf, nil
+}
+
+// countCandidates returns the total number of candidate spawn tables across
+// all pools (i.e. the sum of each pool's length).
+func countCandidates(pools [][]SpawnTableConfig) uint32 {
+	var n uint32
+	for _, pool := range pools {
+		n += uint32(len(pool))
+	}
+	return n
 }
 
 // RoadModeFields carries the computed field values for one RoadMode struct.
@@ -173,35 +195,53 @@ func writeFloors(buf []byte, floors []FloorConfig, base uint32, le binary.ByteOr
 	}
 }
 
-func writeSpawnSection(buf []byte, tables []SpawnTableConfig, ptrsBase, tablesBase uint32, le binary.ByteOrder) {
-	for i, t := range tables {
-		tableOff := tablesBase + uint32(i)*spawnTableByteSize
-		// Pointer entry
+// writeSpawnSection writes, for each pool (slot): a pointer to the pool's
+// first candidate table, the candidate count (len(pool)), and the candidate
+// tables themselves, packed back to back across all pools.
+func writeSpawnSection(buf []byte, pools [][]SpawnTableConfig, ptrsBase, cntsBase, tablesBase uint32, le binary.ByteOrder) {
+	tableOff := tablesBase
+	for i, pool := range pools {
 		le.PutUint32(buf[ptrsBase+uint32(i)*spawnPtrEntrySize:], tableOff)
-		// SpawnTable (32 bytes)
-		le.PutUint32(buf[tableOff:], t.Monster1ID)
-		le.PutUint32(buf[tableOff+4:], t.Monster1Variant)
-		le.PutUint32(buf[tableOff+8:], t.Monster2ID)
-		le.PutUint32(buf[tableOff+12:], t.Monster2Variant)
-		le.PutUint32(buf[tableOff+16:], t.StatTable)
-		le.PutUint32(buf[tableOff+20:], t.MapZoneOverride)
-		le.PutUint32(buf[tableOff+24:], t.SpawnWeighting)
-		le.PutUint32(buf[tableOff+28:], t.AdditionalFlag)
+		le.PutUint32(buf[cntsBase+uint32(i)*spawnPtrEntrySize:], uint32(len(pool)))
+		for _, t := range pool {
+			writeSpawnTable(buf, tableOff, t, le)
+			tableOff += spawnTableByteSize
+		}
 	}
 }
 
+// writeSpawnTable writes one 32-byte SpawnTable entry at off.
+func writeSpawnTable(buf []byte, off uint32, t SpawnTableConfig, le binary.ByteOrder) {
+	le.PutUint32(buf[off:], t.Monster1ID)
+	le.PutUint32(buf[off+4:], t.Monster1Variant)
+	le.PutUint32(buf[off+8:], t.Monster2ID)
+	le.PutUint32(buf[off+12:], t.Monster2Variant)
+	le.PutUint32(buf[off+16:], t.StatTable)
+	le.PutUint32(buf[off+20:], t.MapZoneOverride)
+	le.PutUint32(buf[off+24:], t.SpawnWeighting)
+	le.PutUint32(buf[off+28:], t.AdditionalFlag)
+}
+
 // validateRengokuConfig checks that all spawn_table_index references are
-// within range for both road modes.
+// within range, and that every spawn pool has at least one candidate table,
+// for both road modes. A pool with zero candidates would be written with a
+// candidate count of 0, which crashes the real client on Hunting Road entry.
 func validateRengokuConfig(cfg RengokuConfig) error {
 	for _, road := range []struct {
 		name string
 		r    RoadConfig
 	}{{"multi_road", cfg.MultiRoad}, {"solo_road", cfg.SoloRoad}} {
-		n := len(road.r.SpawnTables)
+		n := len(road.r.SpawnPools)
 		for i, f := range road.r.Floors {
 			if int(f.SpawnTableIndex) >= n {
-				return fmt.Errorf("rengoku: %s floor %d: spawn_table_index %d out of range (have %d tables)",
+				return fmt.Errorf("rengoku: %s floor %d: spawn_table_index %d out of range (have %d spawn pools)",
 					road.name, i, f.SpawnTableIndex, n)
+			}
+		}
+		for i, pool := range road.r.SpawnPools {
+			if len(pool) == 0 {
+				return fmt.Errorf("rengoku: %s spawn_pools[%d]: pool is empty (need at least 1 candidate)",
+					road.name, i)
 			}
 		}
 	}

--- a/server/channelserver/rengoku_build_test.go
+++ b/server/channelserver/rengoku_build_test.go
@@ -1,6 +1,7 @@
 package channelserver
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"math"
 	"os"
@@ -12,12 +13,20 @@ import (
 )
 
 // sampleRengokuConfig returns a small but complete RengokuConfig for tests.
+// Slot 0 is a two-candidate pool (the client rolls between them); slot 1 is a
+// single-candidate pool (fixed spawn).
 func sampleRengokuConfig() RengokuConfig {
-	spawnTables := []SpawnTableConfig{
-		{Monster1ID: 101, Monster1Variant: 0, Monster2ID: 102, Monster2Variant: 1,
-			StatTable: 3, SpawnWeighting: 10},
-		{Monster1ID: 103, Monster1Variant: 2, Monster2ID: 104, Monster2Variant: 0,
-			SpawnWeighting: 20},
+	pools := [][]SpawnTableConfig{
+		{
+			{Monster1ID: 101, Monster1Variant: 0, Monster2ID: 102, Monster2Variant: 1,
+				StatTable: 3, SpawnWeighting: 10},
+			{Monster1ID: 105, Monster1Variant: 1, Monster2ID: 106, Monster2Variant: 0,
+				SpawnWeighting: 15},
+		},
+		{
+			{Monster1ID: 103, Monster1Variant: 2, Monster2ID: 104, Monster2Variant: 0,
+				SpawnWeighting: 20},
+		},
 	}
 	floors := []FloorConfig{
 		{FloorNumber: 1, SpawnTableIndex: 0, PointMulti1: 1.0, PointMulti2: 1.5},
@@ -29,8 +38,8 @@ func sampleRengokuConfig() RengokuConfig {
 		{FloorNumber: 2, SpawnTableIndex: 0, PointMulti1: 1.2, PointMulti2: 2.0},
 	}
 	return RengokuConfig{
-		MultiRoad: RoadConfig{Floors: floors, SpawnTables: spawnTables},
-		SoloRoad:  RoadConfig{Floors: soloFloors, SpawnTables: spawnTables[1:]},
+		MultiRoad: RoadConfig{Floors: floors, SpawnPools: pools},
+		SoloRoad:  RoadConfig{Floors: soloFloors, SpawnPools: pools[1:]},
 	}
 }
 
@@ -52,18 +61,64 @@ func TestBuildRengokuBinary_RoundTrip(t *testing.T) {
 	if info.MultiFloors != len(cfg.MultiRoad.Floors) {
 		t.Errorf("MultiFloors = %d, want %d", info.MultiFloors, len(cfg.MultiRoad.Floors))
 	}
-	if info.MultiSpawnTables != len(cfg.MultiRoad.SpawnTables) {
-		t.Errorf("MultiSpawnTables = %d, want %d", info.MultiSpawnTables, len(cfg.MultiRoad.SpawnTables))
+	if info.MultiSpawnTables != len(cfg.MultiRoad.SpawnPools) {
+		t.Errorf("MultiSpawnTables = %d, want %d", info.MultiSpawnTables, len(cfg.MultiRoad.SpawnPools))
 	}
 	if info.SoloFloors != len(cfg.SoloRoad.Floors) {
 		t.Errorf("SoloFloors = %d, want %d", info.SoloFloors, len(cfg.SoloRoad.Floors))
 	}
-	if info.SoloSpawnTables != len(cfg.SoloRoad.SpawnTables) {
-		t.Errorf("SoloSpawnTables = %d, want %d", info.SoloSpawnTables, len(cfg.SoloRoad.SpawnTables))
+	if info.SoloSpawnTables != len(cfg.SoloRoad.SpawnPools) {
+		t.Errorf("SoloSpawnTables = %d, want %d", info.SoloSpawnTables, len(cfg.SoloRoad.SpawnPools))
 	}
-	// Unique monsters: multi has 101,102,103,104; solo has 103,104 → 4 total
-	if info.UniqueMonsters != 4 {
-		t.Errorf("UniqueMonsters = %d, want 4", info.UniqueMonsters)
+	// Unique monsters: multi pools cover 101,102,105,106,103,104; solo pool
+	// (103,104) is a subset → 6 total.
+	if info.UniqueMonsters != 6 {
+		t.Errorf("UniqueMonsters = %d, want 6", info.UniqueMonsters)
+	}
+}
+
+// TestBuildRengokuBinary_SpawnCounts is a regression test for #206: the
+// candidate count array was left entirely zeroed, which crashes the real
+// client on Hunting Road entry. It verifies every slot's count is non-zero,
+// and that a multi-candidate pool is laid out contiguously with the right
+// count and pointer.
+func TestBuildRengokuBinary_SpawnCounts(t *testing.T) {
+	cfg := sampleRengokuConfig()
+
+	bin, err := BuildRengokuBinary(cfg)
+	if err != nil {
+		t.Fatalf("BuildRengokuBinary: %v", err)
+	}
+
+	multi, err := readRoadMode(bin, rengokuMultiOffset)
+	if err != nil {
+		t.Fatalf("readRoadMode(multi): %v", err)
+	}
+
+	le := binary.LittleEndian
+	for i := uint32(0); i < multi.SpawnTablePtrCount; i++ {
+		count := le.Uint32(bin[multi.SpawnCountPtrsPtr+i*4:])
+		if count == 0 {
+			t.Fatalf("multi slot %d: candidate count is 0 (client would crash on Hunting Road entry)", i)
+		}
+	}
+
+	// Slot 0 is a 2-candidate pool: verify the count and that both
+	// candidates are stored contiguously starting at the slot's pointer.
+	wantCount := uint32(len(cfg.MultiRoad.SpawnPools[0]))
+	gotCount := le.Uint32(bin[multi.SpawnCountPtrsPtr:])
+	if gotCount != wantCount {
+		t.Fatalf("multi slot 0 count = %d, want %d", gotCount, wantCount)
+	}
+
+	slot0TablePtr := le.Uint32(bin[multi.SpawnTablePtrsPtr:])
+	firstMonster := le.Uint32(bin[slot0TablePtr:])
+	secondMonster := le.Uint32(bin[slot0TablePtr+spawnTableByteSize:])
+	if firstMonster != cfg.MultiRoad.SpawnPools[0][0].Monster1ID {
+		t.Errorf("slot 0 candidate 0 Monster1ID = %d, want %d", firstMonster, cfg.MultiRoad.SpawnPools[0][0].Monster1ID)
+	}
+	if secondMonster != cfg.MultiRoad.SpawnPools[0][1].Monster1ID {
+		t.Errorf("slot 0 candidate 1 Monster1ID = %d, want %d", secondMonster, cfg.MultiRoad.SpawnPools[0][1].Monster1ID)
 	}
 }
 
@@ -75,11 +130,11 @@ func TestBuildRengokuBinary_FloatFields(t *testing.T) {
 			Floors: []FloorConfig{
 				{FloorNumber: 1, SpawnTableIndex: 0, PointMulti1: 1.25, PointMulti2: 3.75},
 			},
-			SpawnTables: []SpawnTableConfig{{Monster1ID: 1}},
+			SpawnPools: [][]SpawnTableConfig{{{Monster1ID: 1}}},
 		},
 		SoloRoad: RoadConfig{
-			Floors:      []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 0}},
-			SpawnTables: []SpawnTableConfig{{Monster1ID: 2}},
+			Floors:     []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 0}},
+			SpawnPools: [][]SpawnTableConfig{{{Monster1ID: 2}}},
 		},
 	}
 
@@ -106,7 +161,8 @@ func TestBuildRengokuBinary_FloatFields(t *testing.T) {
 }
 
 // TestBuildRengokuBinary_ValidationErrors verifies that out-of-range
-// spawn_table_index values are caught before the binary is built.
+// spawn_table_index values and empty spawn pools are caught before the
+// binary is built.
 func TestBuildRengokuBinary_ValidationErrors(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -117,12 +173,12 @@ func TestBuildRengokuBinary_ValidationErrors(t *testing.T) {
 			name: "multi_index_out_of_range",
 			cfg: RengokuConfig{
 				MultiRoad: RoadConfig{
-					Floors:      []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 5}},
-					SpawnTables: []SpawnTableConfig{{Monster1ID: 1}},
+					Floors:     []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 5}},
+					SpawnPools: [][]SpawnTableConfig{{{Monster1ID: 1}}},
 				},
 				SoloRoad: RoadConfig{
-					Floors:      []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 0}},
-					SpawnTables: []SpawnTableConfig{{Monster1ID: 2}},
+					Floors:     []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 0}},
+					SpawnPools: [][]SpawnTableConfig{{{Monster1ID: 2}}},
 				},
 			},
 			wantErr: "multi_road",
@@ -131,15 +187,29 @@ func TestBuildRengokuBinary_ValidationErrors(t *testing.T) {
 			name: "solo_index_out_of_range",
 			cfg: RengokuConfig{
 				MultiRoad: RoadConfig{
-					Floors:      []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 0}},
-					SpawnTables: []SpawnTableConfig{{Monster1ID: 1}},
+					Floors:     []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 0}},
+					SpawnPools: [][]SpawnTableConfig{{{Monster1ID: 1}}},
 				},
 				SoloRoad: RoadConfig{
-					Floors:      []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 99}},
-					SpawnTables: []SpawnTableConfig{{Monster1ID: 2}},
+					Floors:     []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 99}},
+					SpawnPools: [][]SpawnTableConfig{{{Monster1ID: 2}}},
 				},
 			},
 			wantErr: "solo_road",
+		},
+		{
+			name: "empty_pool",
+			cfg: RengokuConfig{
+				MultiRoad: RoadConfig{
+					Floors:     []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 0}},
+					SpawnPools: [][]SpawnTableConfig{{}},
+				},
+				SoloRoad: RoadConfig{
+					Floors:     []FloorConfig{{FloorNumber: 1, SpawnTableIndex: 0}},
+					SpawnPools: [][]SpawnTableConfig{{{Monster1ID: 2}}},
+				},
+			},
+			wantErr: "empty",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #206. `BuildRengokuBinary` (the JSON `rengoku_data.json` builder) left the per-slot spawn candidate count array entirely zeroed. The real client dereferences these counts on Hunting Road entry and crashes instantly on 0 — any server using the documented `rengoku_data.json` feature served a binary that hard-crashed real clients, while server logs looked completely healthy.

Root causes and fixes:

- `writeSpawnSection` never wrote the count array → now writes real per-slot counts (`len(pool)`, always ≥ 1).
- The flat `spawn_tables` schema (one table per slot) couldn't represent retail's spawn pools, where each slot holds 5–79 candidate monster configs the client rolls between via `spawn_weighting`. Replaced it with `spawn_pools` (`RoadConfig.SpawnPools [][]SpawnTableConfig`); a floor's `spawn_table_index` now selects a pool instead of a single table.
- `validateRengokuConfig` now rejects empty pools before building (a 0-length pool would still produce a 0 count).
- `parseRengokuBinary`/`countUniqueMonsters` only validated pointer bounds, never count values, so a broken build could pass its own post-build structural validation silently. They now read the count array, reject zero-count slots, and walk every candidate per pool (not just the first).

This is a breaking change to the `rengoku_data.json` schema (`spawn_tables` → `spawn_pools`), but the feature is new and currently unusable against real clients, so there's no working config to preserve compatibility with.

### End-to-end verification (real server, real Postgres, real wire protocol)

Beyond unit tests, I ran this against an actual running server to confirm the fix (and that it would have caught the original bug):

1. Built `erupe-ce` from this branch, ran it against a real PostgreSQL instance with a `bin/rengoku_data.json` using a multi-candidate `spawn_pools` config (one slot with 3 candidates, one with 1; solo road with 2 candidates).
2. Added a `--action rengoku` to `protbot` (included in this PR) that logs in, enters the lobby, sends the real `MSG_MHF_GET_RENGOKU_BINARY` packet, ECD-decrypts the response, and reads back the per-slot candidate counts exactly as the game client would.
3. Against this branch: server logged `Hunting Road config (from JSON)` successfully, and protbot reported `multiDef: candidate counts=[3 1]`, `soloDef: candidate counts=[2]` — all non-zero. ✅
4. To confirm this isn't a vacuous check, I also built `main` (pre-fix) and ran the identical flow with an equivalent legacy `spawn_tables` config: protbot reported `multiDef: candidate counts=[0 0]`, `soloDef: candidate counts=[0]` — reproducing exactly the zero-count bug from the issue, over the real network protocol.

I don't have a real MHF-ZZ client available to reproduce the actual client-side crash, so that part of the repro is unverified by me directly — @Psyke1004, since you offered to test against a real client, it'd be great if you could confirm this patched build no longer crashes on Hunting Road entry.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./... -timeout=10m` (all packages pass)
- [x] `gofmt -l` on changed files (clean)
- [x] `golangci-lint run ./...` (0 issues)
- [x] Added `TestBuildRengokuBinary_SpawnCounts` regression test asserting no slot's count is ever 0, plus new/updated cases in `rengoku_build_test.go` and `rengoku_binary_test.go` covering multi-candidate pools and zero-count rejection
- [x] End-to-end: real server + Postgres + wire protocol confirms non-zero counts on this branch, and reproduces the original zero-count bug on `main`